### PR TITLE
Update Licensing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 Inventoryware requires a recent version of `ruby` (2.5.1<=) and `bundler`.
 The following will install from source using `git`:
 ```
-git clone https://github.com/alces-software/inventoryware.git
+git clone https://github.com/openflighthpc/inventoryware.git
 cd inventoryware
 bundle install
 ```
@@ -36,10 +36,10 @@ yum install https://s3-eu-west-1.amazonaws.com/alces-flight/rpms/flight-core-0.1
 
 ```
 # Standard install
-curl https://raw.githubusercontent.com/alces-software/inventoryware/master/scripts/install |/bin/bash
+curl https://raw.githubusercontent.com/openflighthpc/inventoryware/master/scripts/install |/bin/bash
 
 # Installation with variables
-curl https://raw.githubusercontent.com/alces-software/inventoryware/master/scripts/install |alces_INSTALL_DIR=/my/install/path/ alces_VERSION=dev-release /bin/bash
+curl https://raw.githubusercontent.com/openflighthpc/inventoryware/master/scripts/install |alces_INSTALL_DIR=/my/install/path/ alces_VERSION=dev-release /bin/bash
 ```
 
 ### Local Installation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,11 +2,11 @@
 
 ### Generic
 
-Inventoryware requires a recent version of `ruby` (2.5.1<=) and `bundler`.
+Flight Inventory requires a recent version of `ruby` (2.5.1<=) and `bundler`.
 The following will install from source using `git`:
 ```
-git clone https://github.com/openflighthpc/inventoryware.git
-cd inventoryware
+git clone https://github.com/openflighthpc/flight-inventory.git
+cd flight-inventory
 bundle install
 ```
 
@@ -16,7 +16,7 @@ Note: Interactive editing requires `vim` be installed, this is available in most
 
 ### Flight Core
 
-Inventoryware can be installed as a tool to the flight-core environment.
+Flight Inventory can be installed as a tool to the flight-core environment.
 
 ### Automated Installation
 
@@ -36,15 +36,15 @@ yum install https://s3-eu-west-1.amazonaws.com/alces-flight/rpms/flight-core-0.1
 
 ```
 # Standard install
-curl https://raw.githubusercontent.com/openflighthpc/inventoryware/master/scripts/install |/bin/bash
+curl https://raw.githubusercontent.com/openflighthpc/flight-inventory/master/scripts/install |/bin/bash
 
 # Installation with variables
-curl https://raw.githubusercontent.com/openflighthpc/inventoryware/master/scripts/install |alces_INSTALL_DIR=/my/install/path/ alces_VERSION=dev-release /bin/bash
+curl https://raw.githubusercontent.com/openflighthpc/flight-inventory/master/scripts/install |alces_INSTALL_DIR=/my/install/path/ alces_VERSION=dev-release /bin/bash
 ```
 
 ### Local Installation
 
-Instead of depending on an upstream location, Inventoryware can be installed from a local copy of the repository in the following manner.
+Instead of depending on an upstream location, Flight Inventory can be installed from a local copy of the repository in the following manner.
 
 - Install Flight Core (if not already installed)
 
@@ -54,7 +54,7 @@ yum install https://s3-eu-west-1.amazonaws.com/alces-flight/rpms/flight-core-0.1
 
 - **Note: If Flight Core has just been installed then logout and in again or source `/etc/profile.d/alces-flight.sh`**
 
-- Execute the install script from inside the `inventoryware` directory
+- Execute the install script from inside the `flight-inventory` directory
 
 ```
 bash scripts/install
@@ -66,15 +66,14 @@ bash scripts/install
 
 - Now logout and in again or source `/etc/profile.d/alces-flight.sh`
 
-- Inventoryware can now be run as follows
+- Flight Inventory can now be run as follows
 
 ```
 flight inventory
 ```
 
-- Alternatively, a sandbox environment for Inventoryware can be entered as follows
+- Alternatively, a sandbox environment for Flight Inventory can be entered as follows
 
 ```
 flight shell inventory
 ```
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,25 +1,278 @@
-Copyright (C) 2018-19 Stephen F Norledge & Alces Software Ltd.
+Eclipse Public License - v 2.0
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Affero General Public License for more details.
+1. DEFINITIONS
 
-You should have received a copy of the GNU Affero General Public
-License along with this software.  If not, see
-<http://www.gnu.org/licenses/>.
+"Contribution" means:
 
-This package is available under a dual licensing model whereby use of
-the package in projects that are licensed so as to be compatible with
-AGPL Version 3 may use the package under the terms of that
-license. However, if AGPL Version 3.0 terms are incompatible with your
-planned use of this package, alternative license terms are available
-from Alces Software Ltd - please direct inquiries about licensing to
-licensing@alces-software.com.
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
 
-For more information, please visit <http://www.alces-software.com/>.
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: rsync watch-rsync
 
-REMOTE_DIR='/tmp/inventoryware'
+REMOTE_DIR='/tmp/flight-inventory'
 
 rsync:
 	rsync \

--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ the top level `helpers/` directory and utilise that for filling the specified te
 
 # License
 
-AGPLv3+ License, see LICENSE.txt for details.
+Eclipse Public License 2.0, see LICENSE.txt for details.
 
-Copyright (C) 2017 Alces Software Ltd.
+Copyright (C) 2019-present Alces Flight Ltd.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To aid this there is a MakeFile containing `watch-rsync` instructions
 gem install rerun # If you don't have this already.
 make watch-rsync PASSWORD="password for machine" IP="ip of machine"
 ```
-This will keep your working directory synced to `/tmp/inventoryware`
+This will keep your working directory synced to `/tmp/flight-inventory`
 
 ## Templates
 

--- a/bin/inventory
+++ b/bin/inventory
@@ -1,5 +1,30 @@
 #!/usr/bin/env ruby
-
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 lib_dir = File.join(__FILE__, '../../lib')
 $LOAD_PATH << lib_dir
 ENV['BUNDLE_GEMFILE'] ||= File.join(__FILE__, '../../Gemfile')

--- a/helpers/bios_selector.rb
+++ b/helpers/bios_selector.rb
@@ -1,3 +1,29 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 def select_bios
   product = @node_data.lshw.list.node.product rescue ''
   product = product.downcase.split(' ')

--- a/helpers/checks.rb
+++ b/helpers/checks.rb
@@ -1,24 +1,29 @@
-#==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 def imported?
   @node_hash.key?('lshw') and @node_hash.key?('lsblk')

--- a/helpers/cpu.rb
+++ b/helpers/cpu.rb
@@ -1,3 +1,29 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 def cpus
   def create_cpu(cpu_hash)
     OpenStruct.new(cpu_hash).tap do |o|

--- a/helpers/finders.rb
+++ b/helpers/finders.rb
@@ -1,24 +1,29 @@
-#==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 #value' can be a regular expression or a plain old string
 def find_hashes_with_key_value(obj, key, value, store = [])

--- a/helpers/formatters.rb
+++ b/helpers/formatters.rb
@@ -1,24 +1,29 @@
-#==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 # convert decimal amount of bits to a human readable format
 def format_bits_value(bits_value)

--- a/helpers/memory.rb
+++ b/helpers/memory.rb
@@ -1,3 +1,29 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 # sum the size of each bank of each memory node
 def find_total_memory
   total = 0

--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -1,3 +1,29 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 def network_devices
   def create_net(net_hash)
     OpenStruct.new(net_hash).tap do |o|

--- a/helpers/templaters.rb
+++ b/helpers/templaters.rb
@@ -1,24 +1,29 @@
-#==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 # all subtemplates are to be held in a specific directory of `templates/`
 def render_sub_template(subdir, name)

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands'
 

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands'
 
 require 'commander'

--- a/lib/inventoryware/command.rb
+++ b/lib/inventoryware/command.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 
 module Inventoryware

--- a/lib/inventoryware/command.rb
+++ b/lib/inventoryware/command.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 module Inventoryware
   class Command

--- a/lib/inventoryware/commands.rb
+++ b/lib/inventoryware/commands.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/delete'
 require 'inventoryware/commands/edit'

--- a/lib/inventoryware/commands.rb
+++ b/lib/inventoryware/commands.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/delete'
 require 'inventoryware/commands/edit'
 require 'inventoryware/commands/list'

--- a/lib/inventoryware/commands/delete.rb
+++ b/lib/inventoryware/commands/delete.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'fileutils'

--- a/lib/inventoryware/commands/delete.rb
+++ b/lib/inventoryware/commands/delete.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'fileutils'
 

--- a/lib/inventoryware/commands/edit.rb
+++ b/lib/inventoryware/commands/edit.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/single_node_command'
 require 'tty-editor'
 

--- a/lib/inventoryware/commands/edit.rb
+++ b/lib/inventoryware/commands/edit.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/single_node_command'
 require 'tty-editor'

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'
 

--- a/lib/inventoryware/commands/modifys/groups.rb
+++ b/lib/inventoryware/commands/modifys/groups.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/modifys/groups.rb
+++ b/lib/inventoryware/commands/modifys/groups.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/exceptions'
 require 'inventoryware/node'

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/single_node_command'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/single_node_command'
 require 'inventoryware/exceptions'
 

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/single_node_command'
 

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/single_node_command'
 
 module Inventoryware

--- a/lib/inventoryware/commands/modifys/other.rb
+++ b/lib/inventoryware/commands/modifys/other.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/modifys/other.rb
+++ b/lib/inventoryware/commands/modifys/other.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/exceptions'
 require 'inventoryware/node'

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/exceptions'
 require 'inventoryware/utils'

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/single_node_command'
 

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/single_node_command'
 
 module Inventoryware

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/config'

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/config'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/exceptions'

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/exceptions'
 require 'inventoryware/node'

--- a/lib/inventoryware/config.rb
+++ b/lib/inventoryware/config.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 
 module Inventoryware

--- a/lib/inventoryware/config.rb
+++ b/lib/inventoryware/config.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 module Inventoryware
   class Config

--- a/lib/inventoryware/exceptions.rb
+++ b/lib/inventoryware/exceptions.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 module Inventoryware
   InventorywareError = Class.new(RuntimeError)

--- a/lib/inventoryware/exceptions.rb
+++ b/lib/inventoryware/exceptions.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 
 module Inventoryware

--- a/lib/inventoryware/lsblk_parser.rb
+++ b/lib/inventoryware/lsblk_parser.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 
 # Only designed on lsblk output with the -a (all) and

--- a/lib/inventoryware/lsblk_parser.rb
+++ b/lib/inventoryware/lsblk_parser.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 
 # Only designed on lsblk output with the -a (all) and
 # -P (key/value pairs) options

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/exceptions'
 require 'inventoryware/utils'
 

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/exceptions'
 require 'inventoryware/utils'

--- a/lib/inventoryware/templates_config.rb
+++ b/lib/inventoryware/templates_config.rb
@@ -1,3 +1,30 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
+
 require 'inventoryware/config'
 require 'inventoryware/exceptions'
 

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -1,24 +1,29 @@
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 require 'inventoryware/exceptions'
 
 module Inventoryware

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -1,14 +1,14 @@
 #==============================================================================
-# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Alces Inventoryware.
+# This file/package is part of Inventoryware.
 #
-# Alces Inventoryware is free software: you can redistribute it and/or
+# Inventoryware is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License
 # as published by the Free Software Foundation, either version 3 of
 # the License, or (at your option) any later version.
 #
-# Alces Inventoryware is distributed in the hope that it will be useful,
+# Inventoryware is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Affero General Public License for more details.
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
-# For more information on Alces Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# For more information on Inventoryware, please visit:
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 require 'inventoryware/exceptions'
 

--- a/scripts/install
+++ b/scripts/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 #==============================================================================
-# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
 # This file/package is part of Inventoryware.
 #
@@ -18,7 +18,7 @@
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For more information on the Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 initial_env=$(env)
 alces_INSTALL_DIR="${alces_INSTALL_DIR:-/opt/flight/tools}"
@@ -60,7 +60,7 @@ cd $alces_INSTALL_DIR
 
 if [ ! -z $CLONE ] ; then
     # Install tool
-    git clone https://github.com/alces-software/inventoryware
+    git clone https://github.com/openflighthpc/inventoryware
 fi
 
 cd inventoryware
@@ -80,7 +80,7 @@ cat << EOF > /opt/flight/libexec/commands/inventory
 : VERSION: $alces_VERSION
 : '
 #==============================================================================
-# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019-present Alces Flight Ltd.
 #
 # This file/package is part of Inventoryware.
 #
@@ -98,7 +98,7 @@ cat << EOF > /opt/flight/libexec/commands/inventory
 # along with this package.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For more information on the Inventoryware, please visit:
-# https://github.com/alces-software/inventoryware
+# https://github.com/openflighthpc/inventoryware
 #==============================================================================
 cd $alces_INSTALL_DIR/inventoryware
 export FLIGHT_PROGRAM_NAME="\${flight_NAME} \$(basename \$0)"

--- a/scripts/install
+++ b/scripts/install
@@ -1,25 +1,30 @@
 #!/bin/bash
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on the Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 initial_env=$(env)
 alces_INSTALL_DIR="${alces_INSTALL_DIR:-/opt/flight/tools}"
 alces_VERSION="${alces_VERSION:-2019.1.0}"
@@ -40,7 +45,7 @@ SCRIPT_PARENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 SCRIPT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SCRIPT_BASE=$(basename $SCRIPT_PATH)
 
-if [[ $SCRIPT_BASE != "scripts" ]] ; then 
+if [[ $SCRIPT_BASE != "scripts" ]] ; then
     CLONE=true
     CHECKOUT=true
 else
@@ -79,27 +84,32 @@ cat << EOF > /opt/flight/libexec/commands/inventory
 : SYNOPSIS: A tool for collecting and parsing cluster inventory data
 : VERSION: $alces_VERSION
 : '
-#==============================================================================
+# =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
-# This file/package is part of Inventoryware.
+# This file is part of Flight Inventory.
 #
-# Inventoryware is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Affero General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# Inventoryware is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Affero General Public License for more details.
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
 #
-# For more information on the Inventoryware, please visit:
-# https://github.com/openflighthpc/inventoryware
-#==============================================================================
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
 cd $alces_INSTALL_DIR/inventoryware
 export FLIGHT_PROGRAM_NAME="\${flight_NAME} \$(basename \$0)"
 flexec bundle exec bin/inventory "\$@"

--- a/scripts/install
+++ b/scripts/install
@@ -65,10 +65,10 @@ cd $alces_INSTALL_DIR
 
 if [ ! -z $CLONE ] ; then
     # Install tool
-    git clone https://github.com/openflighthpc/inventoryware
+    git clone https://github.com/openflighthpc/flight-inventory
 fi
 
-cd inventoryware
+cd flight-inventory
 
 if [ ! -z $CHECKOUT ] ; then
     git checkout $alces_VERSION
@@ -110,7 +110,7 @@ cat << EOF > /opt/flight/libexec/commands/inventory
 # For more information on Flight Inventory, please visit:
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
-cd $alces_INSTALL_DIR/inventoryware
+cd $alces_INSTALL_DIR/flight-inventory
 export FLIGHT_PROGRAM_NAME="\${flight_NAME} \$(basename \$0)"
 flexec bundle exec bin/inventory "\$@"
 EOF


### PR DESCRIPTION
This PR updates the licensing details in the library scripts.

Licensing was updated with the following sed (on mac, won't work quite the same on Linux):
```
sed -i '' -e 's/201.* Stephen.*Ltd./2019-present Alces Flight Ltd./g;s/Alces Inventoryware/Inventoryware/g;s/alces-software/openflighthpc/g' FILE
```