### PR TITLE
Group switch on list

### DIFF
--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -138,6 +138,7 @@ module Inventoryware
     command :list do |c|
       cli_syntax(c)
       c.description = "List all assets that have stored data"
+      add_multi_node_options(c)
       action(c, Commands::List)
     end
 

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -26,7 +26,11 @@ module Inventoryware
   module Commands
     class List < MultiNodeCommand
       def run
-        files = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
+        files = if @options.group
+                  find_nodes_in_groups([@options.group])
+                else
+                  Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
+                end
         file_names = get_file_names(files)
         unless file_names.empty?
           puts file_names.sort

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -27,7 +27,7 @@ module Inventoryware
     class List < MultiNodeCommand
       def run
         files = if @options.group
-                  find_nodes_in_groups([@options.group])
+                  find_nodes_in_groups(@options.group.split(','))
                 else
                   Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
                 end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -32,6 +32,7 @@ module Inventoryware
                   Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
                 end
         file_names = get_file_names(files)
+
         unless file_names.empty?
           puts file_names.sort
         else

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -26,13 +26,20 @@ module Inventoryware
   module Commands
     class List < MultiNodeCommand
       def run
-        files = Dir.glob(File.join(Config.yaml_dir, '*.yaml')).map! do |file|
-          File.basename(file, '.yaml')
-        end
-        unless files.empty?
-          puts files.sort
+        files = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
+        file_names = get_file_names(files)
+        unless file_names.empty?
+          puts file_names.sort
         else
           puts "No asset files found within #{File.expand_path(Config.yaml_dir)}"
+        end
+      end
+
+      private
+
+      def get_file_names(files)
+        files.map! do |file|
+          File.basename(file, '.yaml')
         end
       end
     end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -36,6 +36,7 @@ module Inventoryware
         unless file_names.empty?
           puts file_names.sort
         else
+          return if @options.group
           puts "No asset files found within #{File.expand_path(Config.yaml_dir)}"
         end
       end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -24,7 +24,7 @@ require 'inventoryware/config'
 
 module Inventoryware
   module Commands
-    class List < Command
+    class List < MultiNodeCommand
       def run
         files = Dir.glob(File.join(Config.yaml_dir, '*.yaml')).map! do |file|
           File.basename(file, '.yaml')


### PR DESCRIPTION
This PR addresses the first half of #93.

There is now a `--group` option on the `list` command that allows the user to list assets within the specified group(s).