### PR TITLE
Feat/asset types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,3 @@ gem 'rubyzip'
 gem 'tty-editor'
 gem 'xmlhasher'
 gem 'paint'
-
-group :development do
-  gem 'pry'
-  gem 'pry-byebug'
-end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,25 +15,16 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (10.0.2)
-    coderay (1.1.2)
     equatable (0.5.0)
     erubis (2.7.0)
     escape_utils (1.2.1)
     highline (1.7.10)
-    method_source (0.9.2)
     necromancer (0.4.0)
     ox (2.10.0)
     paint (2.1.0)
     pastel (0.7.2)
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
-      pry (~> 0.10)
     recursive-open-struct (1.1.0)
     rubyzip (1.2.2)
     timers (4.3.0)
@@ -67,8 +58,6 @@ DEPENDENCIES
   erubis
   nodeattr_utils!
   paint
-  pry
-  pry-byebug
   recursive-open-struct
   rubyzip
   tty-editor

--- a/etc/templates.conf
+++ b/etc/templates.conf
@@ -1,0 +1,3 @@
+server: templates/serverFC.md.erb
+switch: templates/switch.md.erb
+key: templates/value

--- a/etc/templates.conf
+++ b/etc/templates.conf
@@ -1,3 +1,6 @@
-server: templates/serverFC.md.erb
-switch: templates/switch.md.erb
-key: templates/value
+markdown:
+  server: templates/server.md.erb
+  switch: templates/switch.md.erb
+flightcenter:
+  server: templates/serverFC.md.erb
+  switch: templates/switchFC.md.erb

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -171,6 +171,8 @@ module Inventoryware
       c.option '-l', '--location LOCATION',
                "Output the rendered template to the specified location"
       c.option '-d', '--debug', "Display rendering errors"
+      c.option '-f', '--format FORMAT',
+              'Specify the type of template you would like to render'
       add_multi_node_options(c)
       c.hidden = true
       action(c, Commands::Shows::Document)

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -162,8 +162,12 @@ module Inventoryware
     end
 
     command :'show document' do |c|
-      cli_syntax(c, 'TEMPLATE [ASSET_SPEC]')
+      cli_syntax(c, '[ASSET_SPEC]')
       c.description = "Render a document template for one or more assets"
+      c.option '-t', '--template TEMPLATE',
+        "Render this specific template\n"\
+        "Otherwise use the asset's type to determine the target template "\
+        "from a config file."
       c.option '-l', '--location LOCATION',
                "Output the rendered template to the specified location"
       c.option '-d', '--debug', "Display rendering errors"

--- a/lib/inventoryware/commands/modifys/groups.rb
+++ b/lib/inventoryware/commands/modifys/groups.rb
@@ -37,8 +37,9 @@ Cannot remove a primary group
           group = @argv[0]
 
           find_nodes("group").each do |location|
-            node= Node.new(location)
-            node.create_if_non_existent
+            node = Node.new(location)
+            type = Utils.get_new_asset_type if @options.create
+            node.create_if_non_existent(type)
             if @options.primary
               node.data['mutable']['primary_group'] = group
             else

--- a/lib/inventoryware/commands/modifys/other.rb
+++ b/lib/inventoryware/commands/modifys/other.rb
@@ -46,7 +46,8 @@ Cannot modify '#{field}' this way
 
           find_nodes("modification").each do |location|
             node = Node.new(location)
-            node.create_if_non_existent
+            type = Utils.get_new_asset_type if @options.create
+            node.create_if_non_existent(type)
             if value
               node.data['mutable'][field] = value
             else

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -167,16 +167,18 @@ No .zip files found at #{data_source}
           return false
         end
 
-        node_data = {}
-        node_data['name'] = node_name
-        node_data['mutable'] = {}
+        node_data = {
+          'name' => node_name,
+          'mutable' => {},
+          # extract data from lshw
+          'lshw' => XmlHasher.parse(File.read(file_locations['lshw-xml'])),
+          # extract data from lsblk
+          'lsblk' => LsblkParser.new(file_locations['lsblk-a-P']).hashify(),
+        }
+
         if file_locations['groups']
           node_data['mutable'] = YAML.load(File.read(file_locations['groups']))
         end
-        # extract data from lshw
-        node_data['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))
-        # extract data from lsblk
-        node_data['lsblk'] = LsblkParser.new(file_locations['lsblk-a-P']).hashify()
 
         Utils.exit_unless_dir(Config.yaml_dir)
         yaml_out_name = "#{node_name}.yaml"

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -169,6 +169,7 @@ No .zip files found at #{data_source}
 
         node_data = {
           'name' => node_name,
+          'type' => 'server',
           'mutable' => {},
           # extract data from lshw
           'lshw' => XmlHasher.parse(File.read(file_locations['lshw-xml'])),

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -33,7 +33,7 @@ module Inventoryware
     module Shows
       class Document < MultiNodeCommand
         def run
-          node_locations = find_nodes('template')
+          node_locations = find_nodes()
           node_locations = node_locations.uniq
           node_locations = node_locations.sort_by do |location|
             File.basename(location)
@@ -86,7 +86,7 @@ Invalid destination '#{out_dest}'
         end
 
         def find_template
-          template_arg = @argv[0]
+          template_arg = @options.template
           found = Utils.find_file(template_arg, Config.templates_dir)
 
           if found.length == 1

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -23,6 +23,7 @@ require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/config'
 require 'inventoryware/exceptions'
 require 'inventoryware/node'
+require 'inventoryware/templates_config'
 require 'inventoryware/utils'
 
 require 'erubis'
@@ -92,7 +93,7 @@ Invalid destination '#{out_dest}'
           if @options.template
             template = find_template_as_path(@options.template)
           else
-            template = find_template_from_asset_type(node)
+            template = TemplatesConfig.new.find(@options.format, node.data['type'])
           end
 
           unless File.readable?(template)
@@ -115,27 +116,6 @@ Please refine your search and try again.
           else
             template = template_arg
           end
-        end
-
-        def find_template_from_asset_type(node)
-          unless File.readable?(Config.templates_config_path)
-            raise FileSysError, <<-ERROR.chomp
-Template config at #{Config.templates_config_path} is inaccessible
-            ERROR
-          end
-          templates = Utils.load_yaml(Config.templates_config_path)
-          unless templates.is_a?(Hash)
-            raise ParseError, <<-ERROR.chomp
-Template config at #{Config.templates_config_path} is in an incorrect format
-            ERROR
-          end
-          type = node.data['type']
-          unless templates.keys.include?(type)
-            raise ParseError, <<-ERROR.chomp
-Asset type '#{type}' is not included in template config file
-            ERROR
-          end
-          return templates[type]
         end
 
         # fill the template for a single node

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -118,15 +118,15 @@ Please refine your search and try again.
         end
 
         def find_template_from_asset_type(node)
-          unless File.readable?(Config.template_config_path)
+          unless File.readable?(Config.templates_config_path)
             raise FileSysError, <<-ERROR.chomp
-Template config at #{Config.template_config_path} is inaccessible
+Template config at #{Config.templates_config_path} is inaccessible
             ERROR
           end
-          templates = Utils.load_yaml(Config.template_config_path)
+          templates = Utils.load_yaml(Config.templates_config_path)
           unless templates.is_a?(Hash)
             raise ParseError, <<-ERROR.chomp
-Template config at #{Config.template_config_path} is in an incorrect format
+Template config at #{Config.templates_config_path} is in an incorrect format
             ERROR
           end
           type = node.data['type']

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -90,11 +90,11 @@ Invalid destination '#{out_dest}'
         # method once for all nodes when '@options.template' has a value
         # as the result will always been the same so it's wasted computation
         def find_template(node)
-          if @options.template
-            template = find_template_as_path(@options.template)
-          else
-            template = TemplatesConfig.new.find(@options.format, node.data['type'])
-          end
+          template = if @options.template
+                       find_template_as_path(@options.template)
+                     else
+                       TemplatesConfig.new.find(@options.format, node.data['type'])
+                     end
 
           unless File.readable?(template)
             raise ParseError, <<-ERROR.chomp

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -33,7 +33,7 @@ module Inventoryware
     class SingleNodeCommand < Command
       def run
         name = @argv[0]
-        # error to prevent confusion if attempting to provide >1 node
+        # error to prevent confusion if attempting to provide >1 asset
         if NodeattrUtils::NodeParser.expand(name).length > 1
           raise ArgumentError, <<-ERROR.chomp
 Issue with argument name, please only provide a single asset
@@ -43,7 +43,7 @@ Issue with argument name, please only provide a single asset
         if @options.create
           location = File.join(Config.yaml_dir, "#{name}.yaml")
           node = Node.new(location)
-          node.create_if_non_existent
+          node.create_if_non_existent(Utils.get_new_asset_type)
         else
           found = Utils.find_file(name, Config.yaml_dir)
           unless found.length == 1

--- a/lib/inventoryware/config.rb
+++ b/lib/inventoryware/config.rb
@@ -41,13 +41,15 @@ module Inventoryware
     end
 
     attr_reader :root_dir, :yaml_dir, :templates_dir, :helpers_dir, :req_files,
-      :other_files, :all_files
+      :other_files, :all_files, :template_config_path
 
     def initialize
       @root_dir = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
       @yaml_dir = File.join(@root_dir, 'var/store')
       @templates_dir = File.join(@root_dir, 'templates')
       @helpers_dir = File.join(@root_dir, 'helpers')
+
+      @template_config_path = File.join(@root_dir, 'etc/templates.conf')
 
       @req_files = ["lshw-xml", "lsblk-a-P"]
       @other_files = ["groups"]

--- a/lib/inventoryware/config.rb
+++ b/lib/inventoryware/config.rb
@@ -41,7 +41,7 @@ module Inventoryware
     end
 
     attr_reader :root_dir, :yaml_dir, :templates_dir, :helpers_dir, :req_files,
-      :other_files, :all_files, :template_config_path
+      :other_files, :all_files, :templates_config_path
 
     def initialize
       @root_dir = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
@@ -49,7 +49,7 @@ module Inventoryware
       @templates_dir = File.join(@root_dir, 'templates')
       @helpers_dir = File.join(@root_dir, 'helpers')
 
-      @template_config_path = File.join(@root_dir, 'etc/templates.conf')
+      @templates_config_path = File.join(@root_dir, 'etc/templates.conf')
 
       @req_files = ["lshw-xml", "lsblk-a-P"]
       @other_files = ["groups"]

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -68,11 +68,12 @@ Output file #{@location} not accessible - aborting
       File.open(@location, 'w') { |file| file.write(yaml_hash.to_yaml) }
     end
 
-    def create_if_non_existent
+    def create_if_non_existent(type = '')
       unless Utils.check_file_readable?(@location)
         @data = {
           'name' => @name,
           'mutable' => {},
+          'type' => type,
         }
         save
       end

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -38,16 +38,7 @@ module Inventoryware
     end
 
     def open
-      node_data = nil
-      begin
-        File.open(@location) do |f|
-          node_data = YAML.safe_load(f)
-        end
-      rescue Psych::SyntaxError
-        raise ParseError, <<-ERROR.chomp
-Error parsing yaml in #{@location} - aborting
-        ERROR
-      end
+      node_data = Utils.load_yaml(@location)
       # condition for if the .yaml is empty
       unless node_data
         raise ParseError, <<-ERROR.chomp

--- a/lib/inventoryware/templates_config.rb
+++ b/lib/inventoryware/templates_config.rb
@@ -1,0 +1,54 @@
+require 'inventoryware/config'
+require 'inventoryware/exceptions'
+
+module Inventoryware
+  class TemplatesConfig
+    def initialize
+      @path = Config.templates_config_path
+      unless File.readable?(@path)
+        raise FileSysError, <<-ERROR.chomp
+Template config at #{@path} is inaccessible
+        ERROR
+      end
+    end
+
+    def data
+      @data ||= open
+    end
+
+    def open
+      contents = Utils.load_yaml(@path)
+      unless contents.is_a?(Hash)
+        raise ParseError, <<-ERROR.chomp
+Template config at #{Config.template_config_path} is in an incorrect format
+        ERROR
+      end
+      return contents
+    end
+
+    def find(format = nil, type)
+      if format
+        if data.dig(format, type)
+          return data[format][type]
+        # if a format is specified & it doesn't exist just error
+        # don't continue looking
+        else
+          not_found_error(format, type)
+        end
+      elsif data[type]
+        return data[type]
+      elsif data.values[0][type]
+        return data.values[0][type]
+      else
+        not_found_error(format, type)
+      end
+    end
+
+    def not_found_error(format = nil, type)
+      tag = format ? "Output format '#{format}' with a": 'A'
+      raise ParseError, <<-ERROR.chomp
+#{tag}sset type '#{type}' is not included in template config file
+      ERROR
+    end
+  end
+end

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -78,5 +78,13 @@ Please create it before continuing"
         end
       return results
     end
+
+    def self.get_new_asset_type
+      type = ''
+      while type.empty?
+        type = $terminal.ask('Enter the type of the new assets being created')
+      end
+      return type
+    end
   end
 end

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -86,5 +86,19 @@ Please create it before continuing"
       end
       return type
     end
+
+    def self.load_yaml(path)
+      data = nil
+      begin
+        File.open(path) do |f|
+          data = YAML.safe_load(f)
+        end
+      rescue Psych::SyntaxError
+        raise ParseError, <<-ERROR.chomp
+Error parsing yaml in #{path} - aborting
+        ERROR
+      end
+      return data
+    end
   end
 end

--- a/templates/serverFC.md.erb
+++ b/templates/serverFC.md.erb
@@ -1,0 +1,74 @@
+<%= @node_data.name %>:
+  name: <%= @node_data.name %>
+  primary_group: <%= @node_data.mutable.primary_group %>
+  secondary_group: <%= @node_data.mutable.secondary_groups %>
+  info: |
+    # Sections
+    
+    <% if imported? %>
+    1. [System](#system)
+    1. [Network Devices](#network-devices)
+    1. [Disks](#disks)
+    <% end %>
+    <% if @node_data.mutable.notes -%>1. [Notes](#notes)<% end -%>
+    <% if select_bios %>1. [BIOS Information](#bios-information)<% end %>
+
+<% if imported? %>
+    # System <a name="system"></a>
+    
+    ## Model
+    
+    <%= @node_data.lshw.list.node.product %>
+
+    ## BIOS Version
+
+    <%= find_hashes_with_key_value(@node_hash, 'id', 'firmware')&.first['version'] %>
+
+    ## System Serial Number
+
+    <%= @node_data.lshw.list.node.serial %>
+
+    ## CPU(s)
+
+    <% cpus.each do |cpu| %>
+    ### <%= cpu.id.upcase %>
+
+    Model: <%= cpu.model %>
+    Slot: <%= cpu.slot %>
+
+    <% end %>
+    ## RAM
+
+    - Total: <%= format_bytes_value(find_total_memory) %>
+
+
+    # Network Devices <a name="network-devices"></a>
+
+    | Interface | Speed | MAC |
+    |-----------|-------|-----|
+    <% network_devices.each do |net| %>
+    | <%= net.logicalname %> | <%= net.speed %> | <%= net.serial %> |
+    <% end %>
+
+
+    # Disks <a name="disk"></a>
+
+    | Device | Size |
+    |--------|------|
+    <% @node_data.lsblk.disk&.each_pair do |disk, values| %>
+    | <%= disk %> | <%= values['SIZE'] %> |
+    <% end %>
+
+<% end %>
+    <% if @node_data.mutable.notes -%>
+    # Notes <a name="notes"></a>
+
+    <%= @node_data.mutable.notes.split("\n").join("\n    ") %>
+    <% end -%>
+
+    <% if select_bios %>
+    # BIOS Information <a name="bios-information"></a>
+
+    <%= select_bios.split("\n").join("\n    ") %>
+    <% end %>
+


### PR DESCRIPTION
Closes #89 when merged

Introduces a new top level key in all assets' yaml data - 'type'
This describes what kind of hardware the asset is - server, switch, etc.
When using `parse` imported zips' 'type' is implicitly set to 'server '
When creating a node by any other method the user is prompted on the terminal to input its type

This allows an asset to have a default template
'template' is no longer an argument for `show document`, it is now an option
If the option is passed it's used as it used to be - otherwise the template is determined from the asset's type and the 'templates config' file at `etc/templates.conf` (location defined by `templates_config_path` config value)
 The templates config logic is handled by the new templates config model

Also the `load yaml` method has been extracted to `utils` & `shows/document` has been split into more methods