### PR TITLE
Support editing groups with modify commands

### DIFF
--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -129,9 +129,10 @@ module Inventoryware
     end
 
     command :'modify map' do |c|
-      cli_syntax(c, 'ASSET')
+      cli_syntax(c, '[ASSET_SPEC]')
       c.description = "Modify mapping data for an asset"
       c.hidden = true
+      add_multi_node_options(c)
       add_create_option(c)
       action(c, Commands::Modifys::Map)
     end

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -137,7 +137,7 @@ module Inventoryware
     end
 
     command :'modify notes' do |c|
-      cli_syntax(c, 'ASSET')
+      cli_syntax(c, '[ASSET_SPEC]')
       c.description = "Modify miscellaneous notes for an asset"
       c.hidden = true
       add_multi_node_options(c)

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -130,7 +130,7 @@ module Inventoryware
 
     command :'modify map' do |c|
       cli_syntax(c, '[ASSET_SPEC]')
-      c.description = "Modify mapping data for an asset"
+      c.description = "Modify mapping data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
       add_create_option(c)
@@ -139,7 +139,7 @@ module Inventoryware
 
     command :'modify notes' do |c|
       cli_syntax(c, '[ASSET_SPEC]')
-      c.description = "Modify miscellaneous notes for an asset"
+      c.description = "Modify miscellaneous notes for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
       add_create_option(c)

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -140,6 +140,7 @@ module Inventoryware
       cli_syntax(c, 'ASSET')
       c.description = "Modify miscellaneous notes for an asset"
       c.hidden = true
+      add_multi_node_options(c)
       add_create_option(c)
       action(c, Commands::Modifys::Notes)
     end

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -82,13 +82,17 @@ module Inventoryware
 
       def add_multi_node_options(command)
         command.option '--all', "Select all assets"
-        command.option '-g', '--group GROUP',
-                       "Select assets in GROUP, specify commma-separated list for multiple groups"
+        add_group_option(command)
       end
 
       def add_create_option(command)
         command.option '-c', '--create',
                        "Create specified asset(s) if they don't exist"
+      end
+
+      def add_group_option(command)
+        command.option '-g', '--group GROUP',
+                       "Select assets in GROUP, specify comma-separated list for multiple groups"
       end
     end
 

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -148,7 +148,7 @@ module Inventoryware
     command :list do |c|
       cli_syntax(c)
       c.description = "List all assets that have stored data"
-      add_multi_node_options(c)
+      add_group_option(c)
       action(c, Commands::List)
     end
 

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -87,12 +87,12 @@ module Inventoryware
 
       def add_create_option(command)
         command.option '-c', '--create',
-                       "Create specified asset(s) if they don't exist"
+          "Create specified asset(s) if they don't exist"
       end
 
       def add_group_option(command)
         command.option '-g', '--group GROUP',
-                       "Select assets in GROUP, specify comma-separated list for multiple groups"
+          "Select assets in GROUP, specify comma-separated list for multiple groups"
       end
     end
 

--- a/lib/inventoryware/commands/delete.rb
+++ b/lib/inventoryware/commands/delete.rb
@@ -31,21 +31,17 @@ module Inventoryware
   module Commands
     class Delete < MultiNodeCommand
       def run
-        node_locations = find_nodes()
+        nodes = fetch_nodes()
 
-        unless node_locations.empty?
-          prefix = "You are about to delete"
-          node_locations.map! { |loc| File.expand_path(loc) }
-          if node_locations.length > 1
-            node_msg = "#{prefix}:\n#{node_locations.join("\n")}\nProceed? (y/n)"
-          else
-            node_msg = "#{prefix} #{node_locations[0]} - proceed? (y/n)"
-          end
-          if $terminal.agree(node_msg)
-            node_locations.each { |node| FileUtils.rm node }
-          end
+        prefix = "You are about to delete"
+        node_paths = nodes.map { |n| File.expand_path(n.path) }
+        if node_paths.length > 1
+          node_msg = "#{prefix}:\n#{node_paths.join("\n")}\nProceed? (y/n)"
         else
-          puts "No assets found"
+          node_msg = "#{prefix} #{node_paths[0]} - proceed? (y/n)"
+        end
+        if $terminal.agree(node_msg)
+          node_paths.each { |path| FileUtils.rm path }
         end
       end
     end

--- a/lib/inventoryware/commands/edit.rb
+++ b/lib/inventoryware/commands/edit.rb
@@ -35,7 +35,7 @@ module Inventoryware
         node.save
         # maybe don't create unless saved? i.e. don't create the file above
         # instead save as closing
-        TTY::Editor.open(node.location, command: :rvim)
+        TTY::Editor.open(node.path, command: :rvim)
       end
     end
   end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -30,7 +30,7 @@ require 'inventoryware/utils'
 
 module Inventoryware
   module Commands
-    class List < MultiNodeCommand
+    class List < Command
       def run
         files = if @options.group
                   Utils.find_nodes_in_groups(@options.group.split(','))

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -26,14 +26,14 @@
 # ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'
-require 'inventoryware/utils'
+require 'inventoryware/node'
 
 module Inventoryware
   module Commands
     class List < Command
       def run
         files = if @options.group
-                  Utils.find_nodes_in_groups(@options.group.split(','))
+                  Node.find_nodes_in_groups(@options.group.split(','))
                 else
                   Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
                 end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -26,13 +26,14 @@
 # ==============================================================================
 require 'inventoryware/command'
 require 'inventoryware/config'
+require 'inventoryware/utils'
 
 module Inventoryware
   module Commands
     class List < MultiNodeCommand
       def run
         files = if @options.group
-                  find_nodes_in_groups(@options.group.split(','))
+                  Utils.find_nodes_in_groups(@options.group.split(','))
                 else
                   Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
                 end

--- a/lib/inventoryware/commands/modifys/groups.rb
+++ b/lib/inventoryware/commands/modifys/groups.rb
@@ -41,8 +41,7 @@ Cannot remove a primary group
 
           group = @argv[0]
 
-          find_nodes("group").each do |location|
-            node = Node.new(location)
+          fetch_nodes("group").each do |node|
             type = Utils.get_new_asset_type if @options.create
             node.create_if_non_existent(type)
             if @options.primary

--- a/lib/inventoryware/commands/modifys/groups.rb
+++ b/lib/inventoryware/commands/modifys/groups.rb
@@ -42,8 +42,6 @@ Cannot remove a primary group
           group = @argv[0]
 
           fetch_nodes("group").each do |node|
-            type = Utils.get_new_asset_type if @options.create
-            node.create_if_non_existent(type)
             if @options.primary
               node.data['mutable']['primary_group'] = group
             else

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -24,15 +24,17 @@
 # For more information on Flight Inventory, please visit:
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
-require 'inventoryware/commands/single_node_command'
+require 'inventoryware/commands/multi_node_command'
 require 'inventoryware/exceptions'
+require 'inventoryware/node'
 
 module Inventoryware
   module Commands
     module Modifys
-      class Map < SingleNodeCommand
-        def action(nodes)
-          nodes = *nodes unless nodes.is_a?(Array)
+      class Map < MultiNodeCommand
+        def run
+          nodes = find_nodes()
+          nodes.map! { |n| Node.new(n) }
           node = nodes.first
 
           prompt = TTY::Prompt.new

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -31,16 +31,22 @@ module Inventoryware
   module Commands
     module Modifys
       class Map < SingleNodeCommand
-        def action(node)
+        def action(nodes)
+          nodes = *nodes unless nodes.is_a?(Array)
+          node = nodes.first
+
           prompt = TTY::Prompt.new
           unless prompt.no?('Would you like to add map metadata? (Default: No)')
-            get_map_metadata_from_user(node, prompt)
+            get_map_metadata_from_user(nodes, prompt)
           end
 
           map = map_to_string(node.data['mutable']['map'])
           map = string_to_map(edit_with_tmp_file(map, :"rvim +'set number'"))
-          node.data['mutable']['map'] = map
-          node.save
+
+          nodes.each do |node|
+            node.data['mutable']['map'] = map
+            node.save
+          end
         end
 
         # takes a hash with numerical keys
@@ -74,7 +80,7 @@ Error parsing map - Non-integer keys
           return map
         end
 
-        def get_map_metadata_from_user(node, prompt)
+        def get_map_metadata_from_user(nodes, prompt)
           prompt.say('Enter integer values for the dimensions of the map:')
 
           x = prompt.ask('X:') do |q|
@@ -90,8 +96,10 @@ Error parsing map - Non-integer keys
             %w(DownRight RightDown RightUp UpRight)
           )
 
-          node.data['mutable']['map_dimensions'] = "#{x}x#{y}"
-          node.data['mutable']['map_pattern'] = pattern
+          nodes.each do |node|
+            node.data['mutable']['map_dimensions'] = "#{x}x#{y}"
+            node.data['mutable']['map_pattern'] = pattern
+          end
         end
       end
     end

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -33,8 +33,7 @@ module Inventoryware
     module Modifys
       class Map < MultiNodeCommand
         def run
-          nodes = find_nodes()
-          nodes.map! { |n| Node.new(n) }
+          nodes = fetch_nodes()
           node = nodes.first
 
           prompt = TTY::Prompt.new

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -41,7 +41,8 @@ module Inventoryware
           end
 
           map = map_to_string(node.data['mutable']['map'])
-          map = string_to_map(edit_with_tmp_file(map, :"rvim +'set number'"))
+          map = string_to_map(Utils.edit_with_tmp_file(map,
+                                                       :"rvim +'set number'"))
 
           nodes.each do |node|
             node.data['mutable']['map'] = map

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -38,13 +38,9 @@ module Inventoryware
           notes = edit_with_tmp_file(notes, :rvim).strip
 
           nodes.each do |node|
-            save_notes(node, notes)
+            node.data['mutable']['notes'] = notes
+            node.save
           end
-        end
-
-        def save_notes(node, notes)
-          node.data['mutable']['notes'] = notes
-          node.save
         end
       end
     end

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -32,8 +32,7 @@ module Inventoryware
     module Modifys
       class Notes < MultiNodeCommand
         def run
-          nodes = find_nodes()
-          nodes.map! { |n| Node.new(n) }
+          nodes = fetch_nodes()
           node = nodes.first
 
           notes = node.data['mutable'].fetch('notes', '')

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -30,9 +30,19 @@ module Inventoryware
   module Commands
     module Modifys
       class Notes < SingleNodeCommand
-        def action(node)
+        def action(nodes)
+          nodes = *nodes unless nodes.is_a?(Array)
+          node = nodes.first
+
           notes = node.data['mutable'].fetch('notes', '')
           notes = edit_with_tmp_file(notes, :rvim).strip
+
+          nodes.each do |node|
+            save_notes(node, notes)
+          end
+        end
+
+        def save_notes(node, notes)
           node.data['mutable']['notes'] = notes
           node.save
         end

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -35,7 +35,7 @@ module Inventoryware
           node = nodes.first
 
           notes = node.data['mutable'].fetch('notes', '')
-          notes = edit_with_tmp_file(notes, :rvim).strip
+          notes = Utils.edit_with_tmp_file(notes, :rvim).strip
 
           nodes.each do |node|
             node.data['mutable']['notes'] = notes

--- a/lib/inventoryware/commands/modifys/notes.rb
+++ b/lib/inventoryware/commands/modifys/notes.rb
@@ -24,14 +24,16 @@
 # For more information on Flight Inventory, please visit:
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
-require 'inventoryware/commands/single_node_command'
+require 'inventoryware/commands/multi_node_command'
+require 'inventoryware/node'
 
 module Inventoryware
   module Commands
     module Modifys
-      class Notes < SingleNodeCommand
-        def action(nodes)
-          nodes = *nodes unless nodes.is_a?(Array)
+      class Notes < MultiNodeCommand
+        def run
+          nodes = find_nodes()
+          nodes.map! { |n| Node.new(n) }
           node = nodes.first
 
           notes = node.data['mutable'].fetch('notes', '')

--- a/lib/inventoryware/commands/modifys/other.rb
+++ b/lib/inventoryware/commands/modifys/other.rb
@@ -50,8 +50,6 @@ Cannot modify '#{field}' this way
           end
 
           fetch_nodes("modification").each do |node|
-            type = Utils.get_new_asset_type if @options.create
-            node.create_if_non_existent(type)
             if value
               node.data['mutable'][field] = value
             else

--- a/lib/inventoryware/commands/modifys/other.rb
+++ b/lib/inventoryware/commands/modifys/other.rb
@@ -49,8 +49,7 @@ Cannot modify '#{field}' this way
             ERROR
           end
 
-          find_nodes("modification").each do |location|
-            node = Node.new(location)
+          fetch_nodes("modification").each do |node|
             type = Utils.get_new_asset_type if @options.create
             node.create_if_non_existent(type)
             if value

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -33,12 +33,15 @@ require 'nodeattr_utils'
 module Inventoryware
   module Commands
     class MultiNodeCommand < Command
-      def find_nodes(*args)
+      def fetch_nodes(*args)
         resolve_node_options(@argv, @options, args)
 
         nodes = @argv[args.length]
 
-        node_locations = locate_nodes(nodes, @options)
+        node_paths = find_nodes(nodes, @options)
+        node_paths = node_paths.uniq
+        nodes = node_paths.map { |p| Node.new(p) }
+        #create if non-existant here
       end
 
       private
@@ -64,7 +67,7 @@ There should be no arguments - all assets are being parsed
 
       # given a set of nodes and relevant options returns an expanded list
       #   of all the necessary nodes
-      def locate_nodes(nodes, options)
+      def find_nodes(nodes, options)
         node_locations = []
         if options.all
           node_locations = Node.find_all_nodes

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -67,7 +67,7 @@ There should be no arguments - all assets are being parsed
       def locate_nodes(nodes, options)
         node_locations = []
         if options.all
-          node_locations = find_all_nodes
+          node_locations = Utils.find_all_nodes
         else
           if nodes
             node_locations.push(*find_single_nodes(nodes, !!options.create))

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -41,7 +41,14 @@ module Inventoryware
         node_paths = find_nodes(nodes, @options)
         node_paths = node_paths.uniq
         nodes = node_paths.map { |p| Node.new(p) }
-        #create if non-existant here
+        if @options.create
+          new_nodes = nodes.select { |n| not File.file?(n.path) }
+          unless new_nodes.empty?
+            type = Utils.get_new_asset_type
+            new_nodes.each { |n| n.create_if_non_existent(type) }
+          end
+        end
+        return nodes
       end
 
       private

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -76,6 +76,11 @@ There should be no arguments - all assets are being parsed
             node_locations.push(*Node.find_nodes_in_groups(options.group.split(',')))
           end
         end
+        if node_locations.empty?
+          raise ArgumentError, <<-ERROR.chomp
+No assets found
+          ERROR
+        end
         return node_locations
       end
     end

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -73,46 +73,10 @@ There should be no arguments - all assets are being parsed
             node_locations.push(*find_single_nodes(nodes, !!options.create))
           end
           if options.group
-            node_locations.push(*find_nodes_in_groups(options.group.split(',')))
+            node_locations.push(*Utils.find_nodes_in_groups(options.group.split(',')))
           end
         end
         return node_locations
-      end
-
-      # retrieves all .yaml files in the storage dir
-      def find_all_nodes()
-        node_locations = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
-        if node_locations.empty?
-          $stderr.puts "No asset data found "\
-            "in #{File.expand_path(Config.yaml_dir)}"
-        end
-        return node_locations
-      end
-
-      # retreives all nodes in the given groups
-      # this quite an intensive method of way to go about searching the yaml
-      # each file is converted to a sting and then searched
-      # seems fine as it stands but if speed becomes an issue could stand to
-      #   be changed
-      def find_nodes_in_groups(groups)
-        nodes = []
-        find_all_nodes().each do |location|
-          found = []
-          File.open(location) do |file|
-            contents = file.read
-            m = contents.match(/primary_group: (.*?)$/)
-            found.append(m[1]) if m
-            m = contents.match(/secondary_groups: (.*?)$/)
-            found = found + (m[1].split(',')) if m
-          end
-          unless (found & groups).empty?
-            nodes.append(location)
-          end
-        end
-        if nodes.empty?
-          $stderr.puts "No assets found in #{groups.join(' or ')}."
-        end
-        return nodes
       end
 
       # retreives the .yaml file for each of the given nodes

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -31,7 +31,7 @@ module Inventoryware
     module Shows
       class Data < SingleNodeCommand
         def action(node)
-          File.open(node.location) do |file|
+          File.open(node.path) do |file|
             puts file.read
           end
         end

--- a/lib/inventoryware/commands/shows/document.rb
+++ b/lib/inventoryware/commands/shows/document.rb
@@ -39,24 +39,20 @@ module Inventoryware
     module Shows
       class Document < MultiNodeCommand
         def run
-          node_locations = find_nodes()
-          node_locations = node_locations.uniq
-          node_locations = node_locations.sort_by do |location|
-            File.basename(location)
-          end
+          nodes = fetch_nodes()
+          nodes = nodes.sort_by { |node| node.name }
 
-          output(node_locations, @options.location)
+          output(nodes, @options.location)
         end
 
         private
-        def output(node_locations, out_dest)
+        def output(nodes, out_dest)
           out = ""
           # check, will loading all output cause issues with memory size?
           # probably fine - 723 nodes was 350Kb
-          node_locations.each do |location|
-            node = Node.new(location)
+          nodes.each do |node|
             out += fill_template(node, find_template(node), render_env)
-            $stderr.puts "Rendered #{File.basename(location, '.yaml')}"
+            $stderr.puts "Rendered #{File.basename(node.path, '.yaml')}"
           end
 
           if out_dest
@@ -143,7 +139,7 @@ Please refine your search and try again.
           rescue StandardError => e
             unless @options.debug
               raise ParseError, <<-ERROR.chomp
-Error filling template using #{File.basename(node_location)}.
+Error filling template using #{File.basename(node.path)}.
 Use '--debug' for more information
               ERROR
             else

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -38,7 +38,16 @@ module Inventoryware
     class SingleNodeCommand < Command
       def run
         name = @argv[0]
-        # error to prevent confusion if attempting to provide >1 asset
+
+        # Error to prevent further execution when no argument is specified
+        # for commands with no mandatory arguments e.g. modify notes
+        if name.nil? && !@options
+          raise ArgumentError, <<-ERROR.chomp
+Please provide at least one asset
+          ERROR
+        end
+
+        # error to prevent confusion if attempting to provide >1 node
         if NodeattrUtils::NodeParser.expand(name).length > 1
           raise ArgumentError, <<-ERROR.chomp
 Issue with argument name, please only provide a single asset

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -47,8 +47,14 @@ Issue with argument name, please only provide a single asset
 
         if @options.create
           location = File.join(Config.yaml_dir, "#{name}.yaml")
-          node = Node.new(location)
-          node.create_if_non_existent(Utils.get_new_asset_type)
+          nodes = Node.new(location)
+          nodes.create_if_non_existent(Utils.get_new_asset_type)
+        elsif @options.group
+          node_locations = [*Utils.find_nodes_in_groups(@options.group.split(','))]
+          nodes = []
+          node_locations.each do |location|
+            nodes.push(Node.new(location))
+          end
         else
           found = Utils.find_file(name, Config.yaml_dir)
           unless found.length == 1
@@ -56,10 +62,10 @@ Issue with argument name, please only provide a single asset
 Please refine your search
             ERROR
           end
-          node = Node.new(found[0])
+          nodes = Node.new(found[0])
         end
 
-        action(node)
+        action(nodes)
       end
 
       def action

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -39,14 +39,6 @@ module Inventoryware
       def run
         name = @argv[0]
 
-        # Error to prevent further execution when no argument is specified
-        # for commands with no mandatory arguments e.g. modify notes
-        if name.nil? && !@options
-          raise ArgumentError, <<-ERROR.chomp
-Please provide at least one asset
-          ERROR
-        end
-
         # error to prevent confusion if attempting to provide >1 node
         if NodeattrUtils::NodeParser.expand(name).length > 1
           raise ArgumentError, <<-ERROR.chomp
@@ -56,14 +48,8 @@ Issue with argument name, please only provide a single asset
 
         if @options.create
           location = File.join(Config.yaml_dir, "#{name}.yaml")
-          nodes = Node.new(location)
-          nodes.create_if_non_existent(Utils.get_new_asset_type)
-        elsif @options.group
-          node_locations = [*Node.find_nodes_in_groups(@options.group.split(','))]
-          nodes = []
-          node_locations.each do |location|
-            nodes.push(Node.new(location))
-          end
+          node = Node.new(location)
+          node.create_if_non_existent(Utils.get_new_asset_type)
         else
           found = Utils.find_file(name, Config.yaml_dir)
           unless found.length == 1
@@ -71,10 +57,10 @@ Issue with argument name, please only provide a single asset
 Please refine your search
             ERROR
           end
-          nodes = Node.new(found[0])
+          node = Node.new(found[0])
         end
 
-        action(nodes)
+        action(node)
       end
 
       def action

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -80,20 +80,6 @@ Please refine your search
       def action
         raise NotImplementedError
       end
-
-      def edit_with_tmp_file(text, command)
-        tmp_file = Tempfile.new('inv_ware_file_')
-        begin
-          TTY::Editor.open(tmp_file.path,
-                           content: text,
-                           command: command)
-          edited = tmp_file.read
-        ensure
-          tmp_file.close
-          tmp_file.unlink
-        end
-        return edited
-      end
     end
   end
 end

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -59,7 +59,7 @@ Issue with argument name, please only provide a single asset
           nodes = Node.new(location)
           nodes.create_if_non_existent(Utils.get_new_asset_type)
         elsif @options.group
-          node_locations = [*Utils.find_nodes_in_groups(@options.group.split(','))]
+          node_locations = [*Node.find_nodes_in_groups(@options.group.split(','))]
           nodes = []
           node_locations.each do |location|
             nodes.push(Node.new(location))

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -109,9 +109,9 @@ module Inventoryware
       end
     end
 
-    def initialize(location)
-      @location = location
-      @name = File.basename(location, File.extname(location))
+    def initialize(path)
+      @path = path
+      @name = File.basename(path, File.extname(path))
     end
 
     def data
@@ -123,11 +123,11 @@ module Inventoryware
     end
 
     def open
-      node_data = Utils.load_yaml(@location)
+      node_data = Utils.load_yaml(@path)
       # condition for if the .yaml is empty
       unless node_data
         raise ParseError, <<-ERROR.chomp
-Yaml in #{@location} is empty - aborting
+Yaml in #{@path} is empty - aborting
         ERROR
       end
       @data = node_data.values[0]
@@ -135,17 +135,17 @@ Yaml in #{@location} is empty - aborting
     end
 
     def save
-      unless Utils.check_file_writable?(@location)
+      unless Utils.check_file_writable?(@path)
         raise FileSysError, <<-ERROR.chomp
-Output file #{@location} not accessible - aborting
+Output file #{@path} not accessible - aborting
         ERROR
       end
       yaml_hash = {data['name'] => data}
-      File.open(@location, 'w') { |file| file.write(yaml_hash.to_yaml) }
+      File.open(@path, 'w') { |file| file.write(yaml_hash.to_yaml) }
     end
 
     def create_if_non_existent(type = '')
-      unless Utils.check_file_readable?(@location)
+      unless Utils.check_file_readable?(@path)
         @data = {
           'name' => @name,
           'mutable' => {},
@@ -155,6 +155,6 @@ Output file #{@location} not accessible - aborting
       end
     end
 
-    attr_reader :location, :name
+    attr_reader :path, :name
   end
 end

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -46,6 +46,7 @@ module Inventoryware
       # seems fine as it stands but if speed becomes an issue could stand to
       #   be changed
       def find_nodes_in_groups(groups)
+        groups = *groups unless groups.is_a?(Array)
         nodes = []
         find_all_nodes().each do |location|
           found = []

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -105,5 +105,41 @@ Error parsing yaml in #{path} - aborting
       end
       return data
     end
+
+    # retrieves all .yaml files in the storage dir
+    def self.find_all_nodes()
+      node_locations = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
+      if node_locations.empty?
+        $stderr.puts "No asset data found "\
+          "in #{File.expand_path(Config.yaml_dir)}"
+      end
+      return node_locations
+    end
+
+    # retreives all nodes in the given groups
+    # this quite an intensive method of way to go about searching the yaml
+    # each file is converted to a sting and then searched
+    # seems fine as it stands but if speed becomes an issue could stand to
+    #   be changed
+    def self.find_nodes_in_groups(groups)
+      nodes = []
+      find_all_nodes().each do |location|
+        found = []
+        File.open(location) do |file|
+          contents = file.read
+          m = contents.match(/primary_group: (.*?)$/)
+          found.append(m[1]) if m
+          m = contents.match(/secondary_groups: (.*?)$/)
+          found = found + (m[1].split(',')) if m
+        end
+        unless (found & groups).empty?
+          nodes.append(location)
+        end
+      end
+      if nodes.empty?
+        $stderr.puts "No assets found in #{groups.join(' or ')}."
+      end
+      return nodes
+    end
   end
 end

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -105,5 +105,19 @@ Error parsing yaml in #{path} - aborting
       end
       return data
     end
+
+    def self.edit_with_tmp_file(text, command)
+      tmp_file = Tempfile.new('inv_ware_file_')
+      begin
+        TTY::Editor.open(tmp_file.path,
+                         content: text,
+                         command: command)
+        edited = tmp_file.read
+      ensure
+        tmp_file.close
+        tmp_file.unlink
+      end
+      return edited
+    end
   end
 end

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -105,41 +105,5 @@ Error parsing yaml in #{path} - aborting
       end
       return data
     end
-
-    # retrieves all .yaml files in the storage dir
-    def self.find_all_nodes()
-      node_locations = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
-      if node_locations.empty?
-        $stderr.puts "No asset data found "\
-          "in #{File.expand_path(Config.yaml_dir)}"
-      end
-      return node_locations
-    end
-
-    # retreives all nodes in the given groups
-    # this quite an intensive method of way to go about searching the yaml
-    # each file is converted to a sting and then searched
-    # seems fine as it stands but if speed becomes an issue could stand to
-    #   be changed
-    def self.find_nodes_in_groups(groups)
-      nodes = []
-      find_all_nodes().each do |location|
-        found = []
-        File.open(location) do |file|
-          contents = file.read
-          m = contents.match(/primary_group: (.*?)$/)
-          found.append(m[1]) if m
-          m = contents.match(/secondary_groups: (.*?)$/)
-          found = found + (m[1].split(',')) if m
-        end
-        unless (found & groups).empty?
-          nodes.append(location)
-        end
-      end
-      if nodes.empty?
-        $stderr.puts "No assets found in #{groups.join(' or ')}."
-      end
-      return nodes
-    end
   end
 end


### PR DESCRIPTION
This PR is to address the second half of #93. Both `modify notes` and `modify map` now support the `--group` option. This allows the user to edit data for an entire group from a single editor instance.

After a group has been specified the command will behave no differently than usual for the user. But once they have saved and exited from the editor it will iterate through the group and save the details to each asset.

This does overwrite any existing values for the notes or maps respectively so some caution should probably be exercised when using these commands on a group. Currently there is no warning when running these commands with the group flag but if anyone feels it is 100% necessary and wouldn't get in the way then something could be added fairly easily.

Resolves #93 when merged.