### PR TITLE
Add 'map' option to `show data`

### DIFF
--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -169,6 +169,8 @@ module Inventoryware
     command :'show data' do |c|
       cli_syntax(c, 'ASSET')
       c.description = "View stored data for an asset"
+      c.option '-m', '--map INDEX',
+        "Show the assets listed in the specified index of the specified asset's map"
       c.hidden = true
       action(c, Commands::Shows::Data)
     end


### PR DESCRIPTION
Takes an integer 'index' - the line of the given index of the argument asset's map is scanned and all assets specified in it are taken.
If >1 asset is found the assets' names are displayed. If one asset is found that asset's data file is printed as it show data were called on it.
Closes #109 