### PR TITLE
Fix/list map assets

### DIFF
--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -74,11 +74,9 @@ Asset #{node.name}'s map does not have an index #{index}
             asset_paths << path if File.file?(path)
           end
 
-          if asset_paths.length < 1
+          if asset_paths.empty?
             puts "No assets found under that index"
-          elsif asset_paths.length == 1
-            output_file(asset_paths[0])
-          elsif asset_paths.length > 1
+          else
             puts asset_paths.map { |p| File.basename(p, File.extname(p)) }
           end
         end

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -66,18 +66,17 @@ Asset #{node.name}'s map does not have an index #{index}
           end
 
           line = node.data['mutable']['map'][index]
-          #split on whitespace, commas and equals
-          words = line.split(/[\s,=]/)
-          asset_paths = []
-          words.each do |word|
-            path = File.join(Config.yaml_dir, "#{word}.yaml")
-            asset_paths << path if File.file?(path)
+
+          asset_names = Dir[File.join(Config.yaml_dir, '*')].map do |p|
+            p = File.basename(p, File.extname(p))
           end
 
-          if asset_paths.empty?
+          asset_names.select! { |name| line.include?(name) }
+
+          if asset_names.empty?
             puts "No assets found under that index"
           else
-            puts asset_paths.map { |p| File.basename(p, File.extname(p)) }
+            puts asset_names
           end
         end
       end


### PR DESCRIPTION
Fixes #122 

Changes to the `--map` option of show data.

No longer show data when a single asset is returned
~Demand each word be the name of an asset
Allow assets to end with `-bmc`
Remove splitting on `=`~

CHANGE TO REQUIREMENTS
Now have all assets' names that occur anywhere as substrings be returned
~This should hopefully only run at around 5n operations, where n is the number of assets in the system~
Thinking about it this is fully incorrect as checking a length m string includes a substring takes m operations so this is around n*m +4n operations or O(n*m)

It is also worth noting here how this solution deals with the edge case in which there are asset names that are substrings of other asset names in the system. In the case that the longer asset is specified in the map, they're both returned.

Timing looks like so
```
[root@localhost flight-inventory]# time bin/inventory show data new_node -m 6 
smol001                                                                       
new_switch                                                                    
new_new                                                                       
new                                                                           
                                                                              
real    0m0.376s                                                              
user    0m0.286s                                                              
sys     0m0.088s 
```                                                 
where no command is:
```
  NAME:                                                         
                                                                
    inventory                                                   
                                                                
  DESCRIPTION:                                                  
                                                                
    Parser of hardware information into unified formats.        
                                                                
  COMMANDS:                                                     
                                                                
    create        Create a new asset                            
    delete        Delete the stored data for one or more assets 
    edit          Edit stored data for an asset                 
    help          Display global or [command] help documentation
    list          List all assets that have stored data         
    modify        Change mutable asset data                     
    parse         Parse and store inventory information         
    show          View data                                     
                                                                
  GLOBAL OPTIONS:                                               
                                                                
    -h, --help                                                  
        Display help documentation                              
                                                                
    --version                                                   
        Display version information                             
                                                                
                                                                
real    0m0.367s                                                
user    0m0.318s                                                
sys     0m0.047s                                                
```