### PR TITLE
Feat/type switch on list

### DIFF
--- a/helpers/finders.rb
+++ b/helpers/finders.rb
@@ -25,7 +25,7 @@
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
 
-#value' can be a regular expression or a plain old string
+#'value' can be a regular expression or a plain old string
 def find_hashes_with_key_value(obj, key, value, store = [])
   if obj.respond_to?(:key?) && obj.key?(key) && /#{value}/.match(obj[key])
     store.push(obj)

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -150,6 +150,8 @@ module Inventoryware
       cli_syntax(c)
       c.description = "List all assets that have stored data"
       add_group_option(c)
+      c.option '-t', '--type TYPE',
+        "Select assets in TYPE, specify comma-separated list for multiple types"
       action(c, Commands::List)
     end
 

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -32,14 +32,21 @@ module Inventoryware
   module Commands
     class List < Command
       def run
-        files = if @options.group
-                  Node.find_nodes_in_groups(@options.group.split(','))
+        # note: this process has become quite time intensive when options are
+        # passed -  taking suggestions on speeding it up
+        nodes = if not @options.group and not @options.type
+                  Node.find_all_nodes
                 else
-                  Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
+                  found = []
+                  if @options.group
+                    groups = @options.group.split(',')
+                    found.concat(Node.find_nodes_in_groups(groups))
+                  end
+                  Node.make_unique(found)
                 end
 
-        unless files.empty?
-          type_hash = create_hash_of_types(files.map { |f| Node.new(f) })
+        unless nodes.empty?
+          type_hash = create_hash_of_types(nodes)
           type_hash.each do |k,v|
             puts "##{k.upcase}"
             puts v.sort

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -53,7 +53,7 @@ module Inventoryware
         unless nodes.empty?
           type_hash = create_hash_of_types(nodes)
           type_hash.each do |k,v|
-            puts "##{k.upcase}"
+            puts "\n##{k.upcase}"
             puts v.sort
           end
         else

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -45,8 +45,8 @@ module Inventoryware
             puts v.sort
           end
         else
-          return if @options.group
-          puts "No asset files found within #{File.expand_path(Config.yaml_dir)}"
+          return if @options.group or @options.type
+          $stderr.puts "No asset files found within #{File.expand_path(Config.yaml_dir)}"
         end
       end
 

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -33,18 +33,19 @@ module Inventoryware
     class List < Command
       def run
         # note: this process has become quite time intensive when options are
-        # passed -  taking suggestions on speeding it up
+        # passed - taking suggestions on speeding it up
         nodes = if not @options.group and not @options.type
                   Node.find_all_nodes
                 else
                   found = []
+                  all_nodes = Node.find_all_nodes
                   if @options.group
                     groups = @options.group.split(',')
-                    found.concat(Node.find_nodes_in_groups(groups))
+                    found.concat(Node.find_nodes_in_groups(groups, all_nodes))
                   end
                   if @options.type
                     types = @options.type.split(',')
-                    found.concat(Node.find_nodes_with_types(types))
+                    found.concat(Node.find_nodes_with_types(types, all_nodes))
                   end
                   Node.make_unique(found)
                 end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -42,6 +42,10 @@ module Inventoryware
                     groups = @options.group.split(',')
                     found.concat(Node.find_nodes_in_groups(groups))
                   end
+                  if @options.type
+                    types = @options.type.split(',')
+                    found.concat(Node.find_nodes_with_types(types))
+                  end
                   Node.make_unique(found)
                 end
 

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -74,11 +74,9 @@ Asset #{node.name}'s map does not have an index #{index}
             asset_paths << path if File.file?(path)
           end
 
-          if asset_paths.length < 1
+          if asset_paths.empty?
             puts "No assets found under that index"
-          elsif asset_paths.length == 1
-            output_file(asset_paths[0])
-          elsif asset_paths.length > 1
+          else
             puts asset_paths.map { |p| File.basename(p, File.extname(p)) }
           end
         end

--- a/lib/inventoryware/commands/shows/data.rb
+++ b/lib/inventoryware/commands/shows/data.rb
@@ -66,18 +66,17 @@ Asset #{node.name}'s map does not have an index #{index}
           end
 
           line = node.data['mutable']['map'][index]
-          #split on whitespace, commas and equals
-          words = line.split(/[\s,=]/)
-          asset_paths = []
-          words.each do |word|
-            path = File.join(Config.yaml_dir, "#{word}.yaml")
-            asset_paths << path if File.file?(path)
+
+          asset_names = Dir[File.join(Config.yaml_dir, '*')].map do |p|
+            p = File.basename(p, File.extname(p))
           end
 
-          if asset_paths.empty?
+          asset_names.select! { |name| line.include?(name) }
+
+          if asset_names.empty?
             puts "No assets found under that index"
           else
-            puts asset_paths.map { |p| File.basename(p, File.extname(p)) }
+            puts asset_names
           end
         end
       end

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -41,21 +41,17 @@ module Inventoryware
       end
 
       # retreives all nodes in the given groups
-      # this quite an intensive method of way to go about searching the yaml
-      # each file is converted to a sting and then searched
-      # seems fine as it stands but if speed becomes an issue could stand to
-      #   be changed
+      # note: if speed becomes an issue this should be reverted back to the old
+      # method of converting the yaml to a string and searching with regex
       def find_nodes_in_groups(groups)
+        keys = ['primary_group', 'secondary_groups']
         groups = *groups unless groups.is_a?(Array)
         nodes = []
         find_all_nodes().each do |location|
           found = []
-          File.open(location) do |file|
-            contents = file.read
-            m = contents.match(/primary_group: (.*?)$/)
-            found.append(m[1]) if m
-            m = contents.match(/secondary_groups: (.*?)$/)
-            found = found + (m[1].split(',')) if m
+          mutable = Node.new(location).data['mutable']
+          keys.each do |key|
+            found = found + mutable[key].split(',') if mutable.key?(key)
           end
           unless (found & groups).empty?
             nodes.append(location)

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -43,11 +43,11 @@ module Inventoryware
       # retreives all nodes in the given groups
       # note: if speed becomes an issue this should be reverted back to the old
       # method of converting the yaml to a string and searching with regex
-      def find_nodes_in_groups(groups)
+      def find_nodes_in_groups(groups, node_list = find_all_nodes())
         keys = ['primary_group', 'secondary_groups']
         groups = *groups unless groups.is_a?(Array)
         nodes = []
-        find_all_nodes().each do |node|
+        node_list.each do |node|
           found = []
           mutable = node.data['mutable']
           keys.each do |key|
@@ -66,11 +66,11 @@ module Inventoryware
       # retreives all nodes with the given type
       # This cannot easily be done by converting the yaml to a string and
       # searching with regex as the `lshw` hash has keys called 'type'
-      def find_nodes_with_types(target_types)
+      def find_nodes_with_types(target_types, node_list = find_all_nodes())
         key = ['type']
         target_types = *target_types unless target_types.is_a?(Array)
         nodes = []
-        find_all_nodes().each do |node|
+        node_list.each do |node|
           if target_types.include?(node.type)
             nodes.append(node)
           end

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -63,6 +63,25 @@ module Inventoryware
         return nodes
       end
 
+      # retreives all nodes with the given type
+      # This cannot easily be done by converting the yaml to a string and
+      # searching with regex as the `lshw` hash has keys called 'type'
+      def find_nodes_with_types(target_types)
+        key = ['type']
+        target_types = *target_types unless target_types.is_a?(Array)
+        nodes = []
+        find_all_nodes().each do |location|
+          node_type = Node.new(location).type
+          if target_types.include?(node_type)
+            nodes.append(location)
+          end
+        end
+        if nodes.empty?
+          $stderr.puts "No assets found with type #{target_types.join(' or ')}."
+        end
+        return nodes
+      end
+
       # retreives the .yaml file for each of the given nodes
       # expands node ranges if they exist
       # if return missing is passed, returns paths to the .yamls of non-existent

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -36,6 +36,7 @@ module Inventoryware
       File.extname(path) == ".zip"
     end
 
+    #TODO refine these methods, they're mostly unnecessary
     def self.check_file_writable?(path)
       return false unless check_file_location?(path)
       return false if File.exist?(path) and not File.writable?(path)


### PR DESCRIPTION
Closes #115 

Add a `--type` option to list to filter by asset type. If used with `--group` assets in either the specified group OR with the specified type will be returned.

Also major refactor in the name of efficiency - the 'Node' class methods for finding nodes now return node objects to prevent the same objects being created twice - this involves slight alters of all the places said methods (`find_all_nodes`, `find_nodes_in_groups` and `find_single_nodes` are called) are called.

Additionally change `find_nodes_in_groups` from searching the data file with regex (which is faster) to examining the data hash (which is more precise) 
