### PR TITLE
Point `Gemfile` at v1.1.x release(s) of `commander-openflighthpc`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'commander-openflighthpc', github: 'openflighthpc/commander-openflighthpc', tag: 'develop'
+gem 'commander-openflighthpc', '~> 1.1.0'
 gem 'erubis'
 gem 'nodeattr_utils'
 gem 'recursive-open-struct'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,9 @@
-GIT
-  remote: git://github.com/openflighthpc/commander-openflighthpc.git
-  revision: 1487c2129dd313a90142de8b11fdeaa1bf7f4fa4
-  tag: develop
-  specs:
-    commander-openflighthpc (1.1.0.pre.dev1)
-      highline (~> 1.7.2)
-      paint (~> 2.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
+    commander-openflighthpc (1.1.0)
+      highline (~> 1.7.2)
+      paint (~> 2.1.0)
     equatable (0.5.0)
     erubis (2.7.0)
     escape_utils (1.2.1)
@@ -50,7 +44,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  commander-openflighthpc!
+  commander-openflighthpc (~> 1.1.0)
   erubis
   nodeattr_utils
   paint


### PR DESCRIPTION
Use release version of `commander-openflighthpc` gem.