### PR TITLE
Adjustments to the list command

### DIFF
--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -112,8 +112,9 @@ module Inventoryware
     command :list do |c|
       cli_syntax(c)
       c.description = "List all assets that have stored data"
-      add_group_option(c)
-      c.option '-t', '--type TYPE',
+      c.option '-g', '--group [GROUP]',
+        "Select assets in GROUP, specify comma-separated list for multiple groups"
+      c.option '-t', '--type [TYPE]',
         "Select assets in TYPE, specify comma-separated list for multiple types"
       c.action Commands, :list
     end

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -113,9 +113,9 @@ module Inventoryware
       cli_syntax(c)
       c.description = "List all assets that have stored data"
       c.option '-g', '--group [GROUP]',
-        "Select assets in GROUP, specify comma-separated list for multiple groups"
+        "Optionally select assets in GROUP, specify comma-separated list for multiple groups"
       c.option '-t', '--type [TYPE]',
-        "Select assets in TYPE, specify comma-separated list for multiple types"
+        "Optionally select assets in TYPE, specify comma-separated list for multiple types"
       c.action Commands, :list
     end
 

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -61,14 +61,15 @@ module Inventoryware
 
       private
 
-
       def create_hash_of_attribute(nodes, attr)
         hash = {}
+
         nodes.each do |node|
           key = node.public_send(attr)
           hash[key] = [] unless hash.key?(key)
           hash[key] << node.name
         end
+
         return hash.sort.to_h
       end
 

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -35,11 +35,11 @@ module Inventoryware
         # note: this process has become quite time intensive when options are
         # passed - taking suggestions on speeding it up
 
+        all_nodes = Node.find_all_nodes
         nodes = if not @options.group and not @options.type
                   attr = 'type'
-                  Node.find_all_nodes
+                  all_nodes
                 else
-                  all_nodes = Node.find_all_nodes
                   if @options.group
                     attr = 'primary_group'
                     filter_nodes(all_nodes, @options.group, 'find_nodes_in_groups')

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -39,26 +39,13 @@ module Inventoryware
                   attr = 'type'
                   Node.find_all_nodes
                 else
-                  found = []
                   all_nodes = Node.find_all_nodes
                   if @options.group
-                    unless @options.group == true
-                      groups = @options.group.split(',')
-                      found.concat(Node.find_nodes_in_groups(groups, all_nodes))
-                    end
                     attr = 'primary_group'
-                  end
-                  if @options.type
-                    unless @options.type == true
-                      types = @options.type.split(',')
-                      found.concat(Node.find_nodes_with_types(types, all_nodes))
-                    end
+                    filter_nodes(all_nodes, @options.group, 'find_nodes_in_groups')
+                  elsif @options.type
                     attr = 'type'
-                  end
-                  if found.empty?
-                    all_nodes
-                  else
-                    Node.make_unique(found)
+                    filter_nodes(all_nodes, @options.type, 'find_nodes_with_types')
                   end
                 end
 
@@ -85,6 +72,19 @@ module Inventoryware
           hash[key] << node.name
         end
         return hash.sort.to_h
+      end
+
+      def filter_nodes(nodes, options, search_method)
+        unless options == true
+          found = []
+
+          filter = options.split(',')
+          found.concat(Node.public_send(search_method, filter, nodes))
+
+          Node.make_unique(found)
+        else
+          nodes
+        end
       end
     end
   end

--- a/lib/inventoryware/commands/list.rb
+++ b/lib/inventoryware/commands/list.rb
@@ -36,17 +36,15 @@ module Inventoryware
         # passed - taking suggestions on speeding it up
 
         all_nodes = Node.find_all_nodes
-        nodes = if not @options.group and not @options.type
+        nodes = if @options.group
+                  attr = 'primary_group'
+                  filter_nodes(all_nodes, @options.group, 'find_nodes_in_groups')
+                elsif @options.type
+                  attr = 'type'
+                  filter_nodes(all_nodes, @options.type, 'find_nodes_with_types')
+                else
                   attr = 'type'
                   all_nodes
-                else
-                  if @options.group
-                    attr = 'primary_group'
-                    filter_nodes(all_nodes, @options.group, 'find_nodes_in_groups')
-                  elsif @options.type
-                    attr = 'type'
-                    filter_nodes(all_nodes, @options.type, 'find_nodes_with_types')
-                  end
                 end
 
         unless nodes.empty?

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -179,10 +179,10 @@ module Inventoryware
     # `secondary_groups` in sequence, while only iterating over the file once
     def all_groups
       return secondary_groups << primary_group if @data
-      found = []
+      found = ['orphan']
       quick_search_file do |line|
         if pri_m = line.match(/^  primary_group: (.*)$/)
-          found << pri_m[1]
+          found[0] = pri_m[1]
         elsif sec_m = line.match(/^  secondary_groups: (.*)$/)
           found = found + sec_m[1].split(',')
         end

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -160,8 +160,9 @@ module Inventoryware
 
     def primary_group
       return @data.dig('mutable','primary_group') if @data
+
       # Note the two spaces
-      return quick_search_file('  primary_group')
+      return quick_search_file('  primary_group') || 'orphan'
     end
 
     def secondary_groups


### PR DESCRIPTION
This PR makes some big changes to the `list` command:
* Both the `--group` and `--type` options have optional arguments now
    * This does make the group flag inconsistent with the rest of the commands but it was a necessary evil for the desired functionality.
* If the user provides no argument to these options then they list every asset grouped according to the given option
    * `--group` lists all assets under their primary group
    * `--type` lists all assets under their type (Default behaviour of running `flight inventory list`)
* The `group` option will always place assets under the header of their primary group
    * A future enhancement could look into a way of presenting secondary groups in a nicer format


I did attempt to optimise the listing of groups but couldn't manage to find a decent solution to speed the process up considerably. It is worth revisiting this in the future.

Resolves #134 when merged.