### PR TITLE
Don't generate an error if logicalname is missing for a NIC

### DIFF
--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -34,5 +34,5 @@ def network_devices
   find_hashes_with_key_value(@asset_hash, 'class', 'network')&.each do |net|
     network_devices << create_net(net)
   end
-  network_devices.sort_by {|hsh| hsh[:logicalname] }
+  network_devices.sort_by {|hsh| hsh[:logicalname] || ''}
 end


### PR DESCRIPTION
If a NIC hash doesn't have a logical name FSR, then Flight Inventory crashes. This commit prevents that.

Opened this against master as it's a bug -- don't necessarily merge to `master` but definitely a bugfix/hotfix candidate IMO.