### PR TITLE
Prevent error if switch map has not been defined (i.e. is `nil`).

### DIFF
--- a/templates/switch.md.erb
+++ b/templates/switch.md.erb
@@ -5,7 +5,7 @@
 
 ### Port Layout
 
-  <% map[1]['map'].each do |port, asset| %>
+  <% (map[1]['map'] || {}).each do |port, asset| %>
 <%= port %>: <%= asset %>
   <% end %>
 <% end %>

--- a/templates/switchFC.md.erb
+++ b/templates/switchFC.md.erb
@@ -9,7 +9,7 @@
 
     ### Port Layout
 
-    <% map[1]['map'].each do |port, asset| %>
+    <% (map[1]['map'] || {}).each do |port, asset| %>
     <%= port %>: <%= asset %>
     <% end %>
   <% end %>


### PR DESCRIPTION
If a switch map hasn't been defined then, by default, it is `nil`. The shipped switch templates assume this value is always non-`nil` and the `nil` value causes a crash. This commit prevents that.

Opened this against master as it's a bug -- don't necessarily merge to `master` but definitely a bugfix/hotfix candidate IMO.