### PR TITLE
Add support for clusters

### DIFF
--- a/etc/cluster.yml
+++ b/etc/cluster.yml
@@ -1,0 +1,1 @@
+active_cluster: default

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -161,5 +161,29 @@ module Inventoryware
       c.description = "Create a new asset"
       c.action Commands, :create
     end
+
+    command :'init-cluster' do |c|
+      cli_syntax(c, 'CLUSTER')
+      c.description = "Initialise a new cluster"
+      c.action Commands, :'cluster-init'
+    end
+
+    command :'delete-cluster' do |c|
+      cli_syntax(c, 'CLUSTER')
+      c.description = "Deletes the specified cluster and associated assets"
+      c.action Commands, :'cluster-delete'
+    end
+
+    command :'list-cluster' do |c|
+      cli_syntax(c)
+      c.description = "List the current and available clusters"
+      c.action Commands, :'cluster-list'
+    end
+
+    command :'switch-cluster' do |c|
+      cli_syntax(c, 'CLUSTER')
+      c.description = "Change the current cluster"
+      c.action Commands, :'cluster-switch'
+    end
   end
 end

--- a/lib/inventoryware/commands.rb
+++ b/lib/inventoryware/commands.rb
@@ -35,6 +35,10 @@ require 'inventoryware/commands/modifys/notes'
 require 'inventoryware/commands/modifys/groups'
 require 'inventoryware/commands/import'
 require 'inventoryware/commands/show'
+require 'inventoryware/commands/cluster/init'
+require 'inventoryware/commands/cluster/delete'
+require 'inventoryware/commands/cluster/list'
+require 'inventoryware/commands/cluster/switch'
 
 module Inventoryware
   module Commands

--- a/lib/inventoryware/commands/cluster/delete.rb
+++ b/lib/inventoryware/commands/cluster/delete.rb
@@ -1,0 +1,58 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
+
+require 'inventoryware/config'
+
+require 'fileutils'
+
+module Inventoryware
+  module Commands
+    module Cluster
+      class Delete < Command
+        def run
+          cluster = @argv.first
+
+          prompt = TTY::Prompt.new
+          unless prompt.no?("Are you sure you want to delete '#{cluster}'?")
+            unless cluster == Config.active_cluster
+              puts "Cluster '#{cluster}' has been deleted" if delete_cluster(cluster)
+            else
+              puts "Can't delete the current cluster, please switch cluster first"
+            end
+          end
+        end
+
+        private
+
+        def delete_cluster(cluster)
+          cluster_path = File.join(Config.root_dir, 'var/store', cluster)
+          FileUtils.rm_rf(cluster_path, secure: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/inventoryware/commands/cluster/init.rb
+++ b/lib/inventoryware/commands/cluster/init.rb
@@ -1,0 +1,59 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
+
+require 'inventoryware/config'
+require 'inventoryware/utils'
+
+require 'fileutils'
+
+module Inventoryware
+  module Commands
+    module Cluster
+      class Init < Command
+        def run
+          cluster_config_path = Config.cluster_config_path
+          cluster_config = Utils.load_yaml(cluster_config_path)
+          cluster = @argv.first
+
+          if create_cluster_directory
+            cluster_config['active_cluster'] = cluster
+            Utils.save_yaml(cluster_config_path, cluster_config)
+
+            puts "The '#{cluster}' cluster has been successfully initialised and"\
+                 " is now the active cluster"
+          end
+        end
+
+        private
+
+        def create_cluster_directory
+          FileUtils.mkdir(File.join(Config.root_dir, 'var/store', @argv))
+        end
+      end
+    end
+  end
+end

--- a/lib/inventoryware/commands/cluster/list.rb
+++ b/lib/inventoryware/commands/cluster/list.rb
@@ -1,0 +1,60 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
+
+require 'inventoryware/config'
+
+module Inventoryware
+  module Commands
+    module Cluster
+      class List < Command
+        def run
+          clusters = get_list_of_clusters
+
+          clusters.each do |cluster|
+            puts cluster
+          end
+        end
+
+        private
+
+        def get_list_of_clusters
+          Dir.glob(File.join(Config.root_dir, 'var/store/*')).select { |e|
+            File.directory? e
+          }.map { |dir|
+            File.basename(dir)
+          }.map { |cluster|
+            if cluster == Config.active_cluster
+              "* #{cluster}"
+            else
+              cluster
+            end
+          }.sort
+        end
+      end
+    end
+  end
+end

--- a/lib/inventoryware/commands/cluster/list.rb
+++ b/lib/inventoryware/commands/cluster/list.rb
@@ -35,7 +35,11 @@ module Inventoryware
           clusters = get_list_of_clusters
 
           clusters.each do |cluster|
-            puts cluster
+            if cluster.start_with?('*')
+              puts cluster
+            else
+              puts "  #{cluster}"
+            end
           end
         end
 

--- a/lib/inventoryware/commands/cluster/switch.rb
+++ b/lib/inventoryware/commands/cluster/switch.rb
@@ -1,0 +1,58 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Inventory.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Inventory is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Inventory. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Inventory, please visit:
+# https://github.com/openflighthpc/flight-inventory
+# ==============================================================================
+
+require 'inventoryware/config'
+require 'inventoryware/utils'
+
+module Inventoryware
+  module Commands
+    module Cluster
+      class Switch < Command
+        def run
+          cluster_config_path = Config.cluster_config_path
+          cluster_config = Utils.load_yaml(cluster_config_path)
+          cluster = @argv.first
+
+          if cluster_exists?(cluster)
+            cluster_config["active_cluster"] = cluster
+            Utils.save_yaml(cluster_config_path, cluster_config)
+
+            puts "'#{cluster}' is now the active cluster"
+          else
+            puts "'#{cluster}' is not an existing cluster"
+          end
+        end
+
+        private
+
+        def cluster_exists?(cluster)
+          Dir.exist?(File.join(Config.root_dir, 'var/store', cluster))
+        end
+      end
+    end
+  end
+end

--- a/lib/inventoryware/config.rb
+++ b/lib/inventoryware/config.rb
@@ -25,6 +25,8 @@
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
 
+require 'inventoryware/utils'
+
 module Inventoryware
   class Config
     class << self
@@ -46,16 +48,21 @@ module Inventoryware
     end
 
     attr_reader :root_dir, :yaml_dir, :templates_dir, :helpers_dir, :req_files,
-      :other_files, :all_files, :templates_config_path, :plugins_dir, :req_keys
+      :other_files, :all_files, :templates_config_path, :plugins_dir, :req_keys,
+      :cluster_config_path, :active_cluster
 
     def initialize
       @root_dir = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
-      @yaml_dir = File.join(@root_dir, 'var/store')
+
+      @cluster_config_path = File.join(@root_dir, 'etc/cluster.yml')
+      @templates_config_path = File.join(@root_dir, 'etc/templates.yml')
+
+      @active_cluster = Utils.load_yaml(cluster_config_path)['active_cluster']
+
+      @yaml_dir = File.join(@root_dir, 'var/store', active_cluster)
       @templates_dir = File.join(@root_dir, 'templates')
       @helpers_dir = File.join(@root_dir, 'helpers')
       @plugins_dir = File.join(@root_dir, 'plugins')
-
-      @templates_config_path = File.join(@root_dir, 'etc/templates.yml')
 
       @req_files = ["lshw-xml", "lsblk-a-P"]
       @other_files = ["groups"]

--- a/lib/inventoryware/node.rb
+++ b/lib/inventoryware/node.rb
@@ -220,6 +220,16 @@ Output file #{@path} not accessible - aborting
       File.open(@path, 'w') { |file| file.write(output_yaml) }
     end
 
+    # Moves the asset file. This was created to assist with moving existing assets
+    # to the new format that supports clusters. Use with caution as this has a
+    # fairly significant impact on system functionality.
+    def move(new_path)
+      original_path = self.path
+
+      set_path(new_path)
+      FileUtils.mv(original_path, new_path)
+    end
+
     def create_if_non_existent(type = '')
       unless Utils.check_file_readable?(@path)
         @data = {
@@ -267,6 +277,12 @@ See migrate_data.rb in the scripts directory
     # in order shortly)
     def order_hash(hash)
       Hash[hash.sort_by { |k, _| Config.req_keys.include?(k) ? 0 : 1 }]
+    end
+
+    # Like with the move method this might not see any practical use outside
+    # of moving existing assets to the format supporting clusters
+    def set_path(path)
+      @path = path
     end
   end
 end

--- a/lib/inventoryware/utils.rb
+++ b/lib/inventoryware/utils.rb
@@ -107,6 +107,10 @@ Error parsing yaml in #{path} - aborting
       return data
     end
 
+    def self.save_yaml(path, data)
+      File.open(path, 'w') { |f| f.write data.to_yaml }
+    end
+
     def self.edit_with_tmp_file(text, command)
       tmp_file = Tempfile.new('inv_ware_file_')
       begin

--- a/scripts/migrate_data.rb
+++ b/scripts/migrate_data.rb
@@ -65,19 +65,23 @@ def migrate_asset_schema(asset)
 
       # Update asset schema version number
       asset.data['schema'] = i
-      puts "Successful in updating asset '#{asset.name}' to schema #{i}"
+      puts "Successful in updating asset '#{asset.name}' to schema #{i}" if asset.save
     end
   else
     puts "No changes needed for asset '#{asset.name}' - at schema #{asset_schema}"
   end
-
-  asset.save
 end
 
 # To process all files
 if ARGV.empty?
-  Dir.glob(File.join(Inventoryware::Config.yaml_dir, '*.yaml')).each do |p|
-    migrate_asset_schema(Inventoryware::Node.new(p))
+  Dir.glob(File.join(Inventoryware::Config.root_dir, 'var/store/*')).each do |f|
+    if File.directory?(f)
+      Dir.glob(File.join(f, '*.yaml')).each do |p|
+        migrate_asset_schema(Inventoryware::Node.new(p))
+      end
+    else
+      migrate_asset_schema(Inventoryware::Node.new(f))
+    end
   end
 # To process a specific file
 else

--- a/scripts/migrate_data.rb
+++ b/scripts/migrate_data.rb
@@ -48,6 +48,7 @@ def migrate_asset_schema(asset)
 
   if asset_schema < target_schema
     for i in (asset_schema + 1)..target_schema do
+      # Method to call within corresponding migration file
       method_name = "migrate_to_schema_#{i}"
 
       unless respond_to?(method_name, true)
@@ -62,6 +63,7 @@ def migrate_asset_schema(asset)
       # Call schema migration script
       send(method_name, asset)
 
+      # Update asset schema version number
       asset.data['schema'] = i
       puts "Successful in updating asset '#{asset.name}' to schema #{i}"
     end

--- a/scripts/migrate_data.rb
+++ b/scripts/migrate_data.rb
@@ -82,7 +82,7 @@ if ARGV.empty?
 # To process a specific file
 else
   path = if File.file?(ARGV.first)
-          ARGV.first
+           ARGV.first
          else
            File.join(Inventoryware::Config.yaml_dir, ARGV.first + ".yaml")
          end

--- a/scripts/migrations/schema_1.rb
+++ b/scripts/migrations/schema_1.rb
@@ -44,7 +44,6 @@ def migrate_to_schema_1(asset)
   new_data = asset.data.values[0]
 
   new_data['mutable'] ||= {}
-  new_data['schema'] = 1
   unless new_data['type']
     p "Setting asset '#{asset.name}' to type 'server'"
     new_data['type'] ||= 'server'

--- a/scripts/migrations/schema_3.rb
+++ b/scripts/migrations/schema_3.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # =============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.
 #
@@ -24,8 +25,34 @@
 # For more information on Flight Inventory, please visit:
 # https://github.com/openflighthpc/flight-inventory
 # ==============================================================================
-module Inventoryware
-  VERSION = '1.3.0-dev'
-  SCHEMA_NUM = 3
-  REQ_SCHEMA_NUM = 3
+
+require 'fileutils'
+
+def migrate_to_schema_3(asset)
+  create_default_directory_if_necessary
+
+  if File.dirname(asset.path) == store_dir
+    move_asset_to_default_dir(asset)
+  end
+end
+
+private
+
+def create_default_directory_if_necessary
+  unless Dir.exist? default_dir
+    FileUtils.mkdir(default_dir)
+  end
+end
+
+def move_asset_to_default_dir(asset)
+  filename = File.basename(asset.path)
+  asset.move(File.join(default_dir, filename))
+end
+
+def default_dir
+  File.join(store_dir, 'default')
+end
+
+def store_dir
+  File.join(Inventoryware::Config.root_dir, 'var/store')
 end


### PR DESCRIPTION
This PR introduces the concept of clusters to `Flight Inventory`. The functionality is similar to our other applications that also provide cluster support. 

The `var/store` directory that houses all asset data has been changed. Now every asset is one directory deeper and within a directory for their associated cluster. All commands are run against the currently active cluster and their associated assets within the cluster's directory.

For any existing installations the migration script will need to be run to ensure existing assets are moved to a new default directory; `var/store/default`. The migration will ensure this directory exists and move all assets within `var/store` to this directory. 

There are four commands that handle clusters:
1. `init-cluster`
2. `delete-cluster`
3. `switch-cluster`
4. `list-cluster`

### `init-cluster`

Arguments: `CLUSTER`

Creates a new cluster with the given name and switches to it making it the active cluster. This command creates a new subdirectory within `var/store` with the name of the cluster which will store it's assets.

### `delete-cluster`

Arguments: `CLUSTER`

Deletes the specified cluster and any associated assets within it's directory.

### `switch-cluster`

Arguments: `CLUSTER`

Switches to the specified cluster, making it the active cluster. Any commands run within `Flight Inventory` will be run against this cluster and it's assets.

### `list-cluster`

Lists all available clusters with the active cluster denoted by a `*`.

Resolves #135 when merged.