### PR TITLE
Better Data Handling & Flight Fact Templates

### DIFF
--- a/etc/templates.yml
+++ b/etc/templates.yml
@@ -10,3 +10,5 @@ flightcenter:
   default: serverFC.md.erb
   server: serverFC.md.erb
   switch: switchFC.md.erb
+flightfact:
+  default: flightfact.cmds.erb

--- a/helpers/cpu.rb
+++ b/helpers/cpu.rb
@@ -28,6 +28,15 @@ def cpus
   def create_cpu(cpu_hash)
     OpenStruct.new(cpu_hash).tap do |o|
       o.model = cpu_hash['model'] || cpu_hash['version'] || cpu_hash['product'] || 'No model found'
+
+      # Determine total number of cores
+      ## For metal systems: Uses the "enabledcores" value from lscpu
+      ## For VMs: Each CPU is 1 core (and no enabledcores setting exists)
+      unless o['configuration'].nil?
+        o.cores = find_hashes_with_key_value(o['configuration']['setting'], 'id', 'enabledcores')[0]['value'].to_i
+      else
+        o.cores = 1
+      end
     end
   end
   cpus = []

--- a/helpers/cpu.rb
+++ b/helpers/cpu.rb
@@ -27,7 +27,7 @@
 def cpus
   def create_cpu(cpu_hash)
     OpenStruct.new(cpu_hash).tap do |o|
-      o.model = cpu_hash['model'] || cpu_hash['version'] || 'No model found'
+      o.model = cpu_hash['model'] || cpu_hash['version'] || cpu_hash['product'] || 'No model found'
     end
   end
   cpus = []

--- a/helpers/memory.rb
+++ b/helpers/memory.rb
@@ -28,8 +28,12 @@
 def find_total_memory
   total = 0
   find_hashes_with_key_value(@asset_hash, 'class', 'memory').each do |mem|
-    find_hashes_with_key_value(mem, 'id', '^(bank:).*').each do |bank|
-      total += bank['size'].to_i
+    if find_hashes_with_key_value(mem, 'id', '^(bank:).*').empty?
+      total += mem['size'].to_i
+    else
+      find_hashes_with_key_value(mem, 'id', '^(bank:).*').each do |bank|
+        total += bank['size'].to_i
+      end
     end
   end
   total

--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -32,7 +32,10 @@ def network_devices
   end
   network_devices = []
   find_hashes_with_key_value(@asset_hash, 'class', 'network')&.each do |net|
-    network_devices << create_net(net)
+    # Ignore virtual bridge devices
+    unless net['logicalname'].include? "virbr"
+      network_devices << create_net(net)
+    end
   end
   network_devices.sort_by {|hsh| hsh[:logicalname] || ''}
 end

--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -28,6 +28,14 @@ def network_devices
   def create_net(net_hash)
     OpenStruct.new(net_hash).tap do |o|
       o.speed = format_bits_value((net_hash['capacity'] || net_hash['size'] || 0).to_i)
+
+      # Set speed for Virtual & Infiniband interfaces
+      if o.speed == '0 bit/s' and o.logicalname&.match? /ib/
+        o.speed = 'Infiniband'
+      elsif o.speed == '0 bit/s'
+        o.speed = 'Virtual'
+      end
+
       # Handle logicalname for virtio devices (as information is buried in 'node' hash)
       if o.logicalname.nil?
         o.logicalname = o.node['logicalname']

--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -32,8 +32,8 @@ def network_devices
   end
   network_devices = []
   find_hashes_with_key_value(@asset_hash, 'class', 'network')&.each do |net|
-    # Ignore virtual bridge devices
-    unless net['logicalname'].include? "virbr"
+    # Ignore virtual interfaces (bridges, tunnels and bonds)
+    unless find_hashes_with_key_value(net['configuration']['setting'], 'id', 'driver$')[0]['value'].match? /bridge|tun|bonding/
       network_devices << create_net(net)
     end
   end

--- a/helpers/network_device.rb
+++ b/helpers/network_device.rb
@@ -28,6 +28,15 @@ def network_devices
   def create_net(net_hash)
     OpenStruct.new(net_hash).tap do |o|
       o.speed = format_bits_value((net_hash['capacity'] || net_hash['size'] || 0).to_i)
+      # Handle logicalname for virtio devices (as information is buried in 'node' hash)
+      if o.logicalname.nil?
+        o.logicalname = o.node['logicalname']
+      end
+
+      # Handle mac address for virtio devices
+      if o.serial.nil?
+        o.serial = o.node['serial']
+      end
     end
   end
   network_devices = []

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -23,13 +23,7 @@
 <% network_devices.each do |net| %>
 <%= cmd_base %> 'Interface<%= count %>_Name' '<%= net.logicalname %>'
 <%= cmd_base %> 'Interface<%= count %>_Product' '<%= net.product %> (<%= net.vendor %>)'
-<% if net.speed == '0 bit/s' and net.logicalname.match? /ib/  %>
-<%= cmd_base %> 'Interface<%= count %>_Speed' 'Infiniband'
-<% elsif net.speed == '0 bit/s' %>
-<%= cmd_base %> 'Interface<%= count %>_Speed' 'Virtual'
-<% else %>
 <%= cmd_base %> 'Interface<%= count %>_Speed' '<%= net.speed %>'
-<% end %>
 <%= cmd_base %> 'Interface<%= count %>_MAC' '<%= net.serial %>'
 <% count += 1 %>
 <% end %>

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -1,36 +1,35 @@
 #!/bin/bash
 
-<% cmd_base="flight fact set" %>
-<% cmd_end="--asset #{@asset_data.name}" %>
+<% cmd_base="flight fact set #{@asset_data.name}" %>
 
 # General System Information
-<%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>' <%= cmd_end %>
-<%= cmd_base %> 'BIOS Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>' <%= cmd_end %>
-<%= cmd_base %> 'Serial Number' '<%= @asset_data.lshw.list.node.serial %>' <%= cmd_end %>
+<%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>'
+<%= cmd_base %> 'BIOS Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>'
+<%= cmd_base %> 'Serial Number' '<%= @asset_data.lshw.list.node.serial %>'
 
 # CPUs
 <% cpus.each do |cpu| %>
-<%= cmd_base %> '<%= cpu.id.upcase %> Model' '<%= cpu.model %>' <%= cmd_end %>
-<%= cmd_base %> '<%= cpu.id.upcase %> Slot' '<%= cpu.slot %>' <%= cmd_end %>
+<%= cmd_base %> '<%= cpu.id.upcase %> Model' '<%= cpu.model %>'
+<%= cmd_base %> '<%= cpu.id.upcase %> Slot' '<%= cpu.slot %>'
 <% end %>
 
 # Memory
-<%= cmd_base %> 'Total Memory' '<%= format_bytes_value(find_total_memory) %>' <%= cmd_end %>
+<%= cmd_base %> 'Total Memory' '<%= format_bytes_value(find_total_memory) %>'
 
 # Network Devices
 <% network_devices.each do |net| %>
-<%= cmd_base %> '<%= net.logicalname %> Product' '<%= net.product %> (<%= net.vendor %>)' <%= cmd_end %>
+<%= cmd_base %> '<%= net.logicalname %> Product' '<%= net.product %> (<%= net.vendor %>)'
 <% if net.speed == '0 bit/s' and net.logicalname.match? /ib/  %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' 'Infiniband' <%= cmd_end %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' 'Infiniband'
 <% elsif net.speed == '0 bit/s' %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' 'Virtual' <%= cmd_end %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' 'Virtual'
 <% else %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' '<%= net.speed %>' <%= cmd_end %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' '<%= net.speed %>'
 <% end %>
-<%= cmd_base %> '<%= net.logicalname %> MAC' '<%= net.serial %>' <%= cmd_end %>
+<%= cmd_base %> '<%= net.logicalname %> MAC' '<%= net.serial %>'
 <% end %>
 
 # Storage Devices
 <% @asset_data.lsblk.disk&.each_pair do |disk, values| %>
-<%= cmd_base %> '<%= disk %> Size' '<%= values['SIZE'] %>' <%= cmd_end %>
+<%= cmd_base %> '<%= disk %> Size' '<%= values['SIZE'] %>'
 <% end %>

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+<% cmd_base="flight fact set" %>
+<% cmd_end="--asset #{@asset_data.name}" %>
+
+# General System Information
+<%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>' <%= cmd_end %>
+<%= cmd_base %> 'BIOS Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>' <%= cmd_end %>
+<%= cmd_base %> 'Serial Number' '<%= @asset_data.lshw.list.node.serial %>' <%= cmd_end %>
+
+# CPUs
+<% cpus.each do |cpu| %>
+<%= cmd_base %> '<%= cpu.id.upcase %> Model' '<%= cpu.model %>' <%= cmd_end %>
+<%= cmd_base %> '<%= cpu.id.upcase %> Slot' '<%= cpu.slot %>' <%= cmd_end %>
+<% end %>
+
+# Memory
+<%= cmd_base %> 'Total Memory' '<%= format_bytes_value(find_total_memory) %>' <%= cmd_end %>
+
+# Network Devices
+<% network_devices.each do |net| %>
+<%= cmd_base %> '<%= net.logicalname %> Product' '<%= net.product %> (<%= net.vendor %>)' <%= cmd_end %>
+<% if net.speed == '0 bit/s' and net.logicalname.match? /ib/  %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' 'Infiniband' <%= cmd_end %>
+<% elsif net.speed == '0 bit/s' %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' 'Virtual' <%= cmd_end %>
+<% else %>
+<%= cmd_base %> '<%= net.logicalname %> Speed' '<%= net.speed %>' <%= cmd_end %>
+<% end %>
+<%= cmd_base %> '<%= net.logicalname %> MAC' '<%= net.serial %>' <%= cmd_end %>
+<% end %>
+
+# Storage Devices
+<% @asset_data.lsblk.disk&.each_pair do |disk, values| %>
+<%= cmd_base %> '<%= disk %> Size' '<%= values['SIZE'] %>' <%= cmd_end %>
+<% end %>

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -8,28 +8,37 @@
 <%= cmd_base %> 'Serial_Number' '<%= @asset_data.lshw.list.node.serial %>'
 
 # CPUs
-<% cpus.each do |cpu| %>
-<%= cmd_base %> '<%= cpu.id.upcase %>_Model' '<%= cpu.model %>'
-<%= cmd_base %> '<%= cpu.id.upcase %>_Slot' '<%= cpu.slot %>'
-<% end %>
+<% models = cpus.map(&:model) %>
+<%= cmd_base %> 'CPU_Model' '<%= models.uniq[0] %>'
+<% slots = cpus.map(&:slot) %>
+<%= cmd_base %> 'CPU_Slots' '<%= slots.count %>'
+<% cores = cpus.map { |cpu| cpu.cores } %>
+<%= cmd_base %> 'CPU_Cores_Total' '<%= cores.sum %>'
 
 # Memory
 <%= cmd_base %> 'Total_Memory' '<%= format_bytes_value(find_total_memory) %>'
 
 # Network Devices
+<% count = 1 %>
 <% network_devices.each do |net| %>
-<%= cmd_base %> '<%= net.logicalname %>_Product' '<%= net.product %> (<%= net.vendor %>)'
+<%= cmd_base %> 'Interface<%= count %>_Name' '<%= net.logicalname %>'
+<%= cmd_base %> 'Interface<%= count %>_Product' '<%= net.product %> (<%= net.vendor %>)'
 <% if net.speed == '0 bit/s' and net.logicalname.match? /ib/  %>
-<%= cmd_base %> '<%= net.logicalname %>_Speed' 'Infiniband'
+<%= cmd_base %> 'Interface<%= count %>_Speed' 'Infiniband'
 <% elsif net.speed == '0 bit/s' %>
-<%= cmd_base %> '<%= net.logicalname %>_Speed' 'Virtual'
+<%= cmd_base %> 'Interface<%= count %>_Speed' 'Virtual'
 <% else %>
-<%= cmd_base %> '<%= net.logicalname %>_Speed' '<%= net.speed %>'
+<%= cmd_base %> 'Interface<%= count %>_Speed' '<%= net.speed %>'
 <% end %>
-<%= cmd_base %> '<%= net.logicalname %>_MAC' '<%= net.serial %>'
+<%= cmd_base %> 'Interface<%= count %>_MAC' '<%= net.serial %>'
+<% count += 1 %>
 <% end %>
 
 # Storage Devices
+<% count = 1 %>
 <% @asset_data.lsblk.disk&.each_pair do |disk, values| %>
-<%= cmd_base %> '<%= disk %>_Size' '<%= values['SIZE'] %>'
+<%= cmd_base %> 'Disk<%= count %>_Name' '<%= disk %>'
+<%= cmd_base %> 'Disk<%= count %>_Size' '<%= values['SIZE'] %>'
+<% count += 1 %>
 <% end %>
+

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -4,7 +4,7 @@
 
 # General System Information
 <%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>'
-<%= cmd_base %> 'BIOS_Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>'
+<%= cmd_base %> 'BIOS_Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first&.fetch('version', 'UNKNOWN') %>'
 <%= cmd_base %> 'Serial_Number' '<%= @asset_data.lshw.list.node.serial %>'
 
 # CPUs

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-<% cmd_base="flight fact set #{@asset_data.name}" %>
+<% cmd_base="flight fact set '#{@asset_data.name}'" %>
 
 # General System Information
 <%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>'

--- a/templates/flightfact.cmds.erb
+++ b/templates/flightfact.cmds.erb
@@ -4,32 +4,32 @@
 
 # General System Information
 <%= cmd_base %> 'Model' '<%= @asset_data.lshw.list.node.product %>'
-<%= cmd_base %> 'BIOS Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>'
-<%= cmd_base %> 'Serial Number' '<%= @asset_data.lshw.list.node.serial %>'
+<%= cmd_base %> 'BIOS_Version' '<%= find_hashes_with_key_value(@asset_hash, 'id', 'firmware')&.first['version'] %>'
+<%= cmd_base %> 'Serial_Number' '<%= @asset_data.lshw.list.node.serial %>'
 
 # CPUs
 <% cpus.each do |cpu| %>
-<%= cmd_base %> '<%= cpu.id.upcase %> Model' '<%= cpu.model %>'
-<%= cmd_base %> '<%= cpu.id.upcase %> Slot' '<%= cpu.slot %>'
+<%= cmd_base %> '<%= cpu.id.upcase %>_Model' '<%= cpu.model %>'
+<%= cmd_base %> '<%= cpu.id.upcase %>_Slot' '<%= cpu.slot %>'
 <% end %>
 
 # Memory
-<%= cmd_base %> 'Total Memory' '<%= format_bytes_value(find_total_memory) %>'
+<%= cmd_base %> 'Total_Memory' '<%= format_bytes_value(find_total_memory) %>'
 
 # Network Devices
 <% network_devices.each do |net| %>
-<%= cmd_base %> '<%= net.logicalname %> Product' '<%= net.product %> (<%= net.vendor %>)'
+<%= cmd_base %> '<%= net.logicalname %>_Product' '<%= net.product %> (<%= net.vendor %>)'
 <% if net.speed == '0 bit/s' and net.logicalname.match? /ib/  %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' 'Infiniband'
+<%= cmd_base %> '<%= net.logicalname %>_Speed' 'Infiniband'
 <% elsif net.speed == '0 bit/s' %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' 'Virtual'
+<%= cmd_base %> '<%= net.logicalname %>_Speed' 'Virtual'
 <% else %>
-<%= cmd_base %> '<%= net.logicalname %> Speed' '<%= net.speed %>'
+<%= cmd_base %> '<%= net.logicalname %>_Speed' '<%= net.speed %>'
 <% end %>
-<%= cmd_base %> '<%= net.logicalname %> MAC' '<%= net.serial %>'
+<%= cmd_base %> '<%= net.logicalname %>_MAC' '<%= net.serial %>'
 <% end %>
 
 # Storage Devices
 <% @asset_data.lsblk.disk&.each_pair do |disk, values| %>
-<%= cmd_base %> '<%= disk %> Size' '<%= values['SIZE'] %>'
+<%= cmd_base %> '<%= disk %>_Size' '<%= values['SIZE'] %>'
 <% end %>

--- a/templates/server.md.erb
+++ b/templates/server.md.erb
@@ -32,6 +32,7 @@
 
 Model: <%= cpu.model %>
 Slot: <%= cpu.slot %>
+Cores: <%= cpu.cores %>
 
 <% end %>
 ### RAM

--- a/templates/serverFC.md.erb
+++ b/templates/serverFC.md.erb
@@ -30,6 +30,7 @@
 
 Model: <%= cpu.model %>
 Slot: <%= cpu.slot %>
+Cores: <%= cpu.cores %>
 
 <% end %>
 ## RAM


### PR DESCRIPTION
This PR introduces the following:
- A fix to memory detection on VMs
- Excludes tunnel, bridge and bonding interfaces
- Adds Flight Fact template
    - This template generates a script of `flight fact` commands for putting hardware information into Flight Center using metadata keys
    - The template itself handles another fuzziness/issue in the gathered data by setting virtual interface speed to `Virtual` (instead of 0bit/s) and Infiniband interface speed to `Infiniband` (again, instead of 0bit/s)